### PR TITLE
bug 1468414: change behavior from */users/* users/*

### DIFF
--- a/apps/mdn/mdn-aws/infra/mdn-cdn/cloudfront_primary/cloudfront.tf
+++ b/apps/mdn/mdn-aws/infra/mdn-cdn/cloudfront_primary/cloudfront.tf
@@ -458,7 +458,7 @@ resource "aws_cloudfront_distribution" "mdn-primary-cf-dist" {
 
   # 18
   ordered_cache_behavior {
-    path_pattern = "*/users/*"
+    path_pattern = "users/*"
 
     allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
     cached_methods         = ["GET", "HEAD"]


### PR DESCRIPTION
**This PR updates the Terraform for a CDN behavior to match the changes that have already been made on stage and production.**

Users on the stage and production instances of MDN were seeing login failures (see https://bugzilla.mozilla.org/show_bug.cgi?id=1468414 for example), which were being caused by the login URL (https://developer.allizom.org/users/github/login/?next=...) skipping the`*/users/*` CloudFront behavior (which doesn't cache) and instead being caught by the default behavior, which does cache. In other words, `users/github/login` did not match `*/users/*` but will match `users/*`. The experiment to increase the cache timeout from 5 minutes to 24 hours exposed this bug.