### PR TITLE
update apiVersion of mdn-sync-from-s3-cron.yaml.j2

### DIFF
--- a/apps/mdn/mdn-aws/k8s/mdn-sync-from-s3-cron.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/mdn-sync-from-s3-cron.yaml.j2
@@ -1,4 +1,4 @@
-apiVersion: batch/v2alpha1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: {{ SYNC_FROM_S3_SERVICE_NAME }}
@@ -46,4 +46,3 @@ spec:
               persistentVolumeClaim:
                 claimName: {{ SHARED_PVC_NAME }}
           restartPolicy: OnFailure
-


### PR DESCRIPTION
The `apiVersion` of the `CronJob` resource has changed to `batch/v1beta1` for Kubernetes 1.8+ (see https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/).