### PR TITLE
bug 1467532: Add --fake-initial to migrate

### DIFF
--- a/apps/mdn/mdn-aws/k8s/mdn-db-migration-job.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/mdn-db-migration-job.yaml.j2
@@ -15,3 +15,4 @@ spec:
             - manage.py
             - migrate
             - "--noinput"
+            - "--fake-initial"


### PR DESCRIPTION
Add ``--fake-initial command``, so that the initial migration for django-soapbox 1.5 will be detected in https://github.com/mozilla/kuma/pull/4883/

Once this migration is deployed to all environments (stage, prod, standby, and oregon), ``--fake-initial`` can be removed.