### PR TITLE
bug 1467532: remove --fake-initial from migrate cmd

### DIFF
--- a/apps/mdn/mdn-aws/k8s/mdn-db-migration-job.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/mdn-db-migration-job.yaml.j2
@@ -15,4 +15,3 @@ spec:
             - manage.py
             - migrate
             - "--noinput"
-            - "--fake-initial"


### PR DESCRIPTION
Now that django-soapbox 1.5 has been deployed to all of the MDN instances (stage, prod, standby, and the new stage instance in the IT-owned cluster), and the associated DB's migrated, let's reset the migrate command back to normal.