### PR TITLE
bug 1445641, bug 1464892: remove image tags from config

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -82,7 +82,6 @@ export KUMASCRIPT_NAME ?= kumascript
 export KUMASCRIPT_REPLICAS ?= 1
 export KUMASCRIPT_CONTAINER_PORT ?= ${KUMASCRIPT_SERVICE_TARGET_PORT}
 export KUMASCRIPT_IMAGE ?= quay.io/mozmar/kumascript
-export KUMASCRIPT_IMAGE_TAG ?= latest
 export KUMASCRIPT_IMAGE_PULL_POLICY ?= IfNotPresent
 export KUMASCRIPT_CPU_LIMIT ?= 2
 export KUMASCRIPT_CPU_REQUEST ?= 100m
@@ -90,7 +89,6 @@ export KUMASCRIPT_MEMORY_LIMIT ?= 4Gi
 export KUMASCRIPT_MEMORY_REQUEST ?= 256Mi
 
 export KUMA_IMAGE ?= quay.io/mozmar/kuma
-export KUMA_IMAGE_TAG ?= de455a8
 export KUMA_IMAGE_PULL_POLICY ?= IfNotPresent
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.
 export KUMA_MOUNT_PATH ?= /mdn

--- a/apps/mdn/mdn-aws/k8s/regions/frankfurt/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/frankfurt/prod.mm.sh
@@ -89,7 +89,6 @@ export KUMASCRIPT_NAME=kumascript
 export KUMASCRIPT_REPLICAS=1
 export KUMASCRIPT_CONTAINER_PORT=${KUMASCRIPT_SERVICE_TARGET_PORT}
 export KUMASCRIPT_IMAGE=quay.io/mozmar/kumascript
-export KUMASCRIPT_IMAGE_TAG=62da015
 export KUMASCRIPT_IMAGE_PULL_POLICY=IfNotPresent
 export KUMASCRIPT_CPU_LIMIT=4
 export KUMASCRIPT_CPU_REQUEST=500m
@@ -97,7 +96,6 @@ export KUMASCRIPT_MEMORY_LIMIT=8Gi
 export KUMASCRIPT_MEMORY_REQUEST=2Gi
 
 export KUMA_IMAGE=quay.io/mozmar/kuma
-export KUMA_IMAGE_TAG=bb4c3c2
 export KUMA_IMAGE_PULL_POLICY=IfNotPresent
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.
 export KUMA_MOUNT_PATH=/mdn

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
@@ -89,7 +89,6 @@ export KUMASCRIPT_NAME=kumascript
 export KUMASCRIPT_REPLICAS=1
 export KUMASCRIPT_CONTAINER_PORT=${KUMASCRIPT_SERVICE_TARGET_PORT}
 export KUMASCRIPT_IMAGE=quay.io/mozmar/kumascript
-export KUMASCRIPT_IMAGE_TAG=79334de
 export KUMASCRIPT_IMAGE_PULL_POLICY=IfNotPresent
 export KUMASCRIPT_CPU_LIMIT=2
 export KUMASCRIPT_CPU_REQUEST=100m
@@ -97,7 +96,6 @@ export KUMASCRIPT_MEMORY_LIMIT=4Gi
 export KUMASCRIPT_MEMORY_REQUEST=256Mi
 
 export KUMA_IMAGE=quay.io/mozmar/kuma
-export KUMA_IMAGE_TAG=82e1ab8
 export KUMA_IMAGE_PULL_POLICY=IfNotPresent
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.
 export KUMA_MOUNT_PATH=/mdn

--- a/apps/mdn/mdn-aws/k8s/regions/portland/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/prod.mm.sh
@@ -89,7 +89,6 @@ export KUMASCRIPT_NAME=kumascript
 export KUMASCRIPT_REPLICAS=6
 export KUMASCRIPT_CONTAINER_PORT=${KUMASCRIPT_SERVICE_TARGET_PORT}
 export KUMASCRIPT_IMAGE=quay.io/mozmar/kumascript
-export KUMASCRIPT_IMAGE_TAG=62da015
 export KUMASCRIPT_IMAGE_PULL_POLICY=IfNotPresent
 export KUMASCRIPT_CPU_LIMIT=4
 export KUMASCRIPT_CPU_REQUEST=500m
@@ -97,7 +96,6 @@ export KUMASCRIPT_MEMORY_LIMIT=8Gi
 export KUMASCRIPT_MEMORY_REQUEST=2Gi
 
 export KUMA_IMAGE=quay.io/mozmar/kuma
-export KUMA_IMAGE_TAG=bb4c3c2
 export KUMA_IMAGE_PULL_POLICY=IfNotPresent
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.
 export KUMA_MOUNT_PATH=/mdn

--- a/apps/mdn/mdn-aws/k8s/regions/portland/prod.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/prod.sh
@@ -89,7 +89,6 @@ export KUMASCRIPT_NAME=kumascript
 export KUMASCRIPT_REPLICAS=6
 export KUMASCRIPT_CONTAINER_PORT=${KUMASCRIPT_SERVICE_TARGET_PORT}
 export KUMASCRIPT_IMAGE=quay.io/mozmar/kumascript
-export KUMASCRIPT_IMAGE_TAG=62da015
 export KUMASCRIPT_IMAGE_PULL_POLICY=IfNotPresent
 export KUMASCRIPT_CPU_LIMIT=4
 export KUMASCRIPT_CPU_REQUEST=500m
@@ -97,7 +96,6 @@ export KUMASCRIPT_MEMORY_LIMIT=8Gi
 export KUMASCRIPT_MEMORY_REQUEST=2Gi
 
 export KUMA_IMAGE=quay.io/mozmar/kuma
-export KUMA_IMAGE_TAG=bb4c3c2
 export KUMA_IMAGE_PULL_POLICY=IfNotPresent
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.
 export KUMA_MOUNT_PATH=/mdn

--- a/apps/mdn/mdn-aws/k8s/regions/portland/stage.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/stage.mm.sh
@@ -89,7 +89,6 @@ export KUMASCRIPT_NAME=kumascript
 export KUMASCRIPT_REPLICAS=1
 export KUMASCRIPT_CONTAINER_PORT=${KUMASCRIPT_SERVICE_TARGET_PORT}
 export KUMASCRIPT_IMAGE=quay.io/mozmar/kumascript
-export KUMASCRIPT_IMAGE_TAG=3f719ac
 export KUMASCRIPT_IMAGE_PULL_POLICY=IfNotPresent
 export KUMASCRIPT_CPU_LIMIT=2
 export KUMASCRIPT_CPU_REQUEST=100m
@@ -97,7 +96,6 @@ export KUMASCRIPT_MEMORY_LIMIT=4Gi
 export KUMASCRIPT_MEMORY_REQUEST=256Mi
 
 export KUMA_IMAGE=quay.io/mozmar/kuma
-export KUMA_IMAGE_TAG=bb4c3c2
 export KUMA_IMAGE_PULL_POLICY=IfNotPresent
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.
 export KUMA_MOUNT_PATH=/mdn

--- a/apps/mdn/mdn-aws/k8s/regions/portland/stage.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/stage.sh
@@ -89,7 +89,6 @@ export KUMASCRIPT_NAME=kumascript
 export KUMASCRIPT_REPLICAS=1
 export KUMASCRIPT_CONTAINER_PORT=${KUMASCRIPT_SERVICE_TARGET_PORT}
 export KUMASCRIPT_IMAGE=quay.io/mozmar/kumascript
-export KUMASCRIPT_IMAGE_TAG=3f719ac
 export KUMASCRIPT_IMAGE_PULL_POLICY=IfNotPresent
 export KUMASCRIPT_CPU_LIMIT=2
 export KUMASCRIPT_CPU_REQUEST=100m
@@ -97,7 +96,6 @@ export KUMASCRIPT_MEMORY_LIMIT=4Gi
 export KUMASCRIPT_MEMORY_REQUEST=256Mi
 
 export KUMA_IMAGE=quay.io/mozmar/kuma
-export KUMA_IMAGE_TAG=bb4c3c2
 export KUMA_IMAGE_PULL_POLICY=IfNotPresent
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.
 export KUMA_MOUNT_PATH=/mdn


### PR DESCRIPTION
Setting `KUMA_IMAGE_TAG` and `KUMASCRIPT_IMAGE_TAG` within the regional configuration scripts as well as optionally within the `Makefile` was done for convenience in early development. Now it just causes problems, so remove them.