### PR TITLE
Add REDIS_BASE_URL and REDIS_CACHE_SERVER to kuma

### DIFF
--- a/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
@@ -125,6 +125,16 @@
               value: {{ KUMA_PROTOCOL }}
             - name: RATELIMIT_ENABLE
               value: "{{ KUMA_RATELIMIT_ENABLE }}"
+            - name: REDIS_BASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: mdn-secrets
+                  key: redis-base-url
+            - name: REDIS_CACHE_SERVER
+              valueFrom:
+                secretKeyRef:
+                  name: mdn-secrets
+                  key: redis-url-2
             - name: SECURE_HSTS_SECONDS
               value: "{{ KUMA_SECURE_HSTS_SECONDS }}"
             - name: SENTRY_DSN


### PR DESCRIPTION
``REDIS_CACHE_SERVER`` is required for the changes in mozilla/kuma#4870, which switch from a dual cache based on local memory and memcache, to a single default Redis cache.

``REDIS_BASE_URL`` is for a future change that consolidates all the Redis cache settings.