### PR TITLE
adjust settings for new IT cluster and hosted domain

### DIFF
--- a/apps/mdn/mdn-aws/k8s/mdn-admin-node.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/mdn-admin-node.yaml.j2
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: {{ ADMIN_NODE_NAME }}
-          image: debian
+          image: mysql
           command: [ "/bin/bash", "-c", "--" ]
           args: [ "while true; do sleep 30; done;" ]
           volumeMounts:

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 echo '--> Setting environment to STAGE in PORTLAND'
 
-export KUBECONFIG=${HOME}/.kube/mozilla-mdn.config
+export KUBECONFIG=${HOME}/.kube/oregon.config
 
 # Define defaults for environment variables that personalize the commands.
 export TARGET_ENVIRONMENT=stage
@@ -18,7 +18,7 @@ export SHARED_PV_NAME=mdn-shared-${TARGET_ENVIRONMENT}
 export SHARED_PV_SIZE=1000Gi
 export SHARED_PV_RECLAIM_POLICY=Retain
 export SHARED_PV_MOUNT_PATH=/
-export SHARED_PV_ARN=fs-7b4120d2.efs.us-west-2.amazonaws.com
+export SHARED_PV_ARN=fs-676d25ce.efs.us-west-2.amazonaws.com
 export SHARED_PV_STORAGE_CLASS_NAME=efs
 
 export SHARED_PVC_NAME=mdn-shared
@@ -29,7 +29,7 @@ export WEB_SERVICE_TYPE=LoadBalancer
 export WEB_SERVICE_PORT=443
 export WEB_SERVICE_TARGET_PORT=8000
 export WEB_SERVICE_PROTOCOL=TCP
-export WEB_SERVICE_CERT_ARN=arn:aws:acm:us-west-2:178589013767:certificate/2f399635-126c-4e83-bf43-5ddbd0525719
+export WEB_SERVICE_CERT_ARN=arn:aws:acm:us-west-2:178589013767:certificate/a750fd1f-44b8-4914-ab4a-bd5400ebf043
 
 export API_SERVICE_NAME=api
 export API_SERVICE_TYPE=ClusterIP
@@ -51,7 +51,7 @@ export WEB_CPU_LIMIT=2
 export WEB_CPU_REQUEST=100m
 export WEB_MEMORY_LIMIT=4Gi
 export WEB_MEMORY_REQUEST=256Mi
-export WEB_ALLOWED_HOSTS="developer.mozilla-mdn.nubis.allizom.org,stage.mozilla-mdn.nubis.allizom.org,files.mozilla-mdn.nubis.allizom.org"
+export WEB_ALLOWED_HOSTS="developer-stage.mdn.mozit.cloud,stage.mdn.mozit.cloud,files-stage.mdn.mozit.cloud"
 
 export API_NAME=api
 export API_REPLICAS=1
@@ -88,14 +88,14 @@ export CELERY_CAM_MEMORY_REQUEST=256Mi
 export KUMASCRIPT_NAME=kumascript
 export KUMASCRIPT_REPLICAS=1
 export KUMASCRIPT_CONTAINER_PORT=${KUMASCRIPT_SERVICE_TARGET_PORT}
-export KUMASCRIPT_IMAGE=quay.io/mozmar/kumascript
+export KUMASCRIPT_IMAGE=mdnwebdocs/kumascript
 export KUMASCRIPT_IMAGE_PULL_POLICY=IfNotPresent
 export KUMASCRIPT_CPU_LIMIT=2
 export KUMASCRIPT_CPU_REQUEST=100m
 export KUMASCRIPT_MEMORY_LIMIT=4Gi
 export KUMASCRIPT_MEMORY_REQUEST=256Mi
 
-export KUMA_IMAGE=quay.io/mozmar/kuma
+export KUMA_IMAGE=mdnwebdocs/kuma
 export KUMA_IMAGE_PULL_POLICY=IfNotPresent
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.
 export KUMA_MOUNT_PATH=/mdn
@@ -103,14 +103,14 @@ export KUMA_MOUNT_PATH=/mdn
 export KUMA_ACCOUNT_DEFAULT_HTTP_PROTOCOL=https
 export KUMA_ADMIN_NAMES="MDN devs"
 export KUMA_ALLOW_ROBOTS=False
-export KUMA_ATTACHMENT_HOST=files.mozilla-mdn.nubis.allizom.org
+export KUMA_ATTACHMENT_HOST=files-stage.mdn.mozit.cloud
 unset KUMA_ATTACHMENT_ORIGIN
 export KUMA_CELERY_ALWAYS_EAGER=False
 export KUMA_CELERYD_MAX_TASKS_PER_CHILD=0
 export KUMA_CSRF_COOKIE_SECURE=True
 export KUMA_DEBUG=False
 export KUMA_DEBUG_TOOLBAR=False
-export KUMA_DOMAIN=developer.mozilla-mdn.nubis.allizom.org
+export KUMA_DOMAIN=developer-stage.mdn.mozit.cloud
 export KUMA_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
 export KUMA_ENABLE_CANDIDATE_LANGUAGES=True
 export KUMA_ES_INDEX_PREFIX=mdnstage-oregon
@@ -120,13 +120,13 @@ export KUMA_LEGACY_HOSTS=""
 export KUMA_LEGACY_ROOT=/mdn/www
 export KUMA_MAINTENANCE_MODE=False
 export KUMA_MEDIA_ROOT=/mdn/www
-export KUMA_MEDIA_URL=https://developer.mozilla-mdn.nubis.allizom.org/media/
+export KUMA_MEDIA_URL=https://developer-stage.mdn.mozit.cloud/media/
 export KUMA_PROTOCOL="https://"
 export KUMA_SECURE_HSTS_SECONDS=63072000
 export KUMA_SERVE_LEGACY=True
 export KUMA_SESSION_COOKIE_SECURE=True
-export KUMA_STATIC_URL=https://developer.mozilla-mdn.nubis.allizom.org/static/
+export KUMA_STATIC_URL=https://developer-stage.mdn.mozit.cloud/static/
 export KUMA_WEB_CONCURRENCY=4
 
-export SYNC_BUCKET=s3://mdn-shared-backup-8c8641b943fc3a0f
-export BACKUP_BUCKET=s3://mdn-shared-backup-8c8641b943fc3a0f
+export SYNC_BUCKET=s3://mdn-shared-backup-c2037ed87dd96008
+export BACKUP_BUCKET=s3://mdn-shared-backup-c2037ed87dd96008


### PR DESCRIPTION
This PR reflects the changes made in AWS and used to successfully spin-up https://developer-stage.mdn.mozit.cloud/en-US/. One thing to note is that I changed the name of the Kubernetes config file to `oregon.config`. I'm happy to use a different name if desired.

Also, I changed the image of the `mdn-admin` deployment from `debian` to `mysql`. The `mysql` image is based on the `debian` image but much more useful since the mysql client is pre-installed.