### PR TITLE
Add some more non-cached error headers

### DIFF
--- a/apps/mdn/mdn-aws/infra/mdn-cdn/cloudfront_primary/README.md
+++ b/apps/mdn/mdn-aws/infra/mdn-cdn/cloudfront_primary/README.md
@@ -9,8 +9,13 @@ behavior's path pattern. All of the behaviors will automatically handle
 compression, but GZip only (Brotli compression is not yet supported).
 
 Cloudfront will cache many error responses by default, so we include
-four custom error responses that effectively turn-off the caching of
-`403`'s, `404`'s, `500`'s and `504`'s.
+custom error responses that effectively turn-off the caching for:
+* `403 Forbidden`
+* `404 Not Found`
+* `408 Request Timeout`
+* `500 Internal Server Error`
+* `502 Bad Gateway`
+* `504 Gateway Timeout`
 
 Cloudfront ignores the `Vary` header. All desired cache variance must be
 explicitly configured via the header, cookie, and query-parameter configuration

--- a/apps/mdn/mdn-aws/infra/mdn-cdn/cloudfront_primary/cloudfront.tf
+++ b/apps/mdn/mdn-aws/infra/mdn-cdn/cloudfront_primary/cloudfront.tf
@@ -30,7 +30,17 @@ resource "aws_cloudfront_distribution" "mdn-primary-cf-dist" {
 
   custom_error_response {
     error_caching_min_ttl = 0
+    error_code            = 408
+  }
+
+  custom_error_response {
+    error_caching_min_ttl = 0
     error_code            = 500
+  }
+
+  custom_error_response {
+    error_caching_min_ttl = 0
+    error_code            = 502
   }
 
   custom_error_response {


### PR DESCRIPTION
* ``408 Request Timeout`` may have caused [bug 1479306](https://bugzilla.mozilla.org/show_bug.cgi?id=1479306) to linger for a few days.
* ``502 Bad Gateway`` was associated with a New Relic alert that appeared to go away in a few minutes.