### PR TITLE
Remove custom response for 408 errors

### DIFF
--- a/apps/mdn/mdn-aws/infra/mdn-cdn/cloudfront_primary/README.md
+++ b/apps/mdn/mdn-aws/infra/mdn-cdn/cloudfront_primary/README.md
@@ -8,16 +8,16 @@ the list and finding the first match between the request path and the
 behavior's path pattern. All of the behaviors will automatically handle
 compression, but GZip only (Brotli compression is not yet supported).
 
-Cloudfront will cache many error responses by default, so we include
-custom error responses that effectively turn-off the caching for:
+CloudFront will
+[cache many error responses by default](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/HTTPStatusCodes.html#HTTPStatusCodes-cached-errors),
+so we include custom error responses that effectively turn-off the caching for:
 * `403 Forbidden`
 * `404 Not Found`
-* `408 Request Timeout`
 * `500 Internal Server Error`
 * `502 Bad Gateway`
 * `504 Gateway Timeout`
 
-Cloudfront ignores the `Vary` header. All desired cache variance must be
+CloudFront ignores the `Vary` header. All desired cache variance must be
 explicitly configured via the header, cookie, and query-parameter configuration
 within each behavior.
 

--- a/apps/mdn/mdn-aws/infra/mdn-cdn/cloudfront_primary/cloudfront.tf
+++ b/apps/mdn/mdn-aws/infra/mdn-cdn/cloudfront_primary/cloudfront.tf
@@ -30,11 +30,6 @@ resource "aws_cloudfront_distribution" "mdn-primary-cf-dist" {
 
   custom_error_response {
     error_caching_min_ttl = 0
-    error_code            = 408
-  }
-
-  custom_error_response {
-    error_caching_min_ttl = 0
     error_code            = 500
   }
 


### PR DESCRIPTION
``408 Request Timeout`` is not one of the cached error messages, according to the [CloudFront docs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/HTTPStatusCodes.html#HTTPStatusCodes-cached-errors).