### PR TITLE
bug 1482159: Add live samples URL to KS config

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -120,6 +120,7 @@ export KUMA_WEB_CONCURRENCY ?= 4
 # Derived environment variables for both Kuma and Kumascript. These are always set.
 export KUMA_URL_TEMPLATE_FOR_KUMASCRIPT=http://${KUMASCRIPT_SERVICE_NAME}:${KUMASCRIPT_SERVICE_PORT}/docs/{path}
 export KUMASCRIPT_DOCUMENT_URL_TEMPLATE=http://${API_SERVICE_NAME}/en-US/docs/{path}?raw=1
+export KUMASCRIPT_LIVE_SAMPLES_BASE_URL=${KUMA_PROTOCOL}${KUMA_ATTACHMENT_HOST}
 
 # MDN backup tool
 export BACKUP_SERVICE_NAME ?= mdn-backup-${TARGET_ENVIRONMENT}

--- a/apps/mdn/mdn-aws/k8s/kumascript.deploy.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kumascript.deploy.yaml.j2
@@ -20,6 +20,8 @@ spec:
           ports:
             - containerPort: {{ KUMASCRIPT_CONTAINER_PORT }}
           env:
+            - name: live_samples__base_url
+              value: {{ KUMASCRIPT_LIVE_SAMPLES_BASE_URL }}
             - name: log__console
               value: "true"
             - name: server__template_root_dir


### PR DESCRIPTION
Derive the live samples URL from the Kuma environment variables, and pass to the KumaScript configuration, as added in https://github.com/mdn/kumascript/pull/777