### PR TITLE
handle INTERACTIVE_EXAMPLES_BASE env setting

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -106,6 +106,7 @@ export KUMA_DOMAIN ?= mdn-dev.moz.works
 export KUMA_EMAIL_BACKEND ?= django.core.mail.backends.smtp.EmailBackend
 export KUMA_ES_INDEX_PREFIX ?= mdn
 export KUMA_ES_LIVE_INDEX ?= False
+export KUMA_INTERACTIVE_EXAMPLES_BASE ?= https://interactive-examples.mdn.mozilla.net
 export KUMA_LEGACY_ROOT ?= /mdn/www
 export KUMA_MAINTENANCE_MODE ?= False
 export KUMA_MEDIA_ROOT ?= /mdn/www

--- a/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
@@ -87,6 +87,8 @@
                   key: elasticsearch-url
             - name: FOUNDATION_CALLOUT
               value: "{{ KUMA_FOUNDATION_CALLOUT }}"
+            - name: INTERACTIVE_EXAMPLES_BASE
+              value: "{{ KUMA_INTERACTIVE_EXAMPLES_BASE }}"
             - name: KUMASCRIPT_URL_TEMPLATE
               value: {{ KUMA_URL_TEMPLATE_FOR_KUMASCRIPT }}
             - name: LEGACY_HOSTS

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.min.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.min.sh
@@ -117,6 +117,7 @@ export KUMA_ENABLE_CANDIDATE_LANGUAGES=False
 export KUMA_ES_INDEX_PREFIX=mdnprod
 export KUMA_ES_LIVE_INDEX=True
 export KUMA_FOUNDATION_CALLOUT=False
+export KUMA_INTERACTIVE_EXAMPLES_BASE=https://interactive-examples.mdn.mozit.cloud
 export KUMA_LEGACY_HOSTS="cdn.mdn.mozilla.net,developer.mozilla.com,mdn.mozilla.org,developer-new.mozilla.org,developers.mozilla.org"
 export KUMA_LEGACY_ROOT=/mdn/www
 export KUMA_MAINTENANCE_MODE=True

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.sh
@@ -116,6 +116,7 @@ export KUMA_ENABLE_CANDIDATE_LANGUAGES=False
 export KUMA_ES_INDEX_PREFIX=mdnprod
 export KUMA_ES_LIVE_INDEX=True
 export KUMA_FOUNDATION_CALLOUT=False
+export KUMA_INTERACTIVE_EXAMPLES_BASE=https://interactive-examples.mdn.mozit.cloud
 export KUMA_LEGACY_HOSTS="cdn.mdn.mozilla.net,developer.mozilla.com,mdn.mozilla.org,developer-new.mozilla.org,developers.mozilla.org"
 export KUMA_LEGACY_ROOT=/mdn/www
 export KUMA_MAINTENANCE_MODE=True


### PR DESCRIPTION
Accommodate the new `INTERACTIVE_EXAMPLES_BASE` setting. This has already been deployed to the prod PoC instance.