### PR TITLE
handle interactive-examples setting for kuma & kumascript

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -106,7 +106,6 @@ export KUMA_DOMAIN ?= mdn-dev.moz.works
 export KUMA_EMAIL_BACKEND ?= django.core.mail.backends.smtp.EmailBackend
 export KUMA_ES_INDEX_PREFIX ?= mdn
 export KUMA_ES_LIVE_INDEX ?= False
-export KUMA_INTERACTIVE_EXAMPLES_BASE ?= https://interactive-examples.mdn.mozilla.net
 export KUMA_LEGACY_ROOT ?= /mdn/www
 export KUMA_MAINTENANCE_MODE ?= False
 export KUMA_MEDIA_ROOT ?= /mdn/www
@@ -117,6 +116,8 @@ export KUMA_SERVE_LEGACY ?= True
 export KUMA_SESSION_COOKIE_SECURE ?= True
 export KUMA_STATIC_URL ?= /static/
 export KUMA_WEB_CONCURRENCY ?= 4
+
+export INTERACTIVE_EXAMPLES_BASE_URL ?= https://interactive-examples.mdn.mozilla.net
 
 # Derived environment variables for both Kuma and Kumascript. These are always set.
 export KUMA_URL_TEMPLATE_FOR_KUMASCRIPT=http://${KUMASCRIPT_SERVICE_NAME}:${KUMASCRIPT_SERVICE_PORT}/docs/{path}

--- a/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
@@ -88,7 +88,7 @@
             - name: FOUNDATION_CALLOUT
               value: "{{ KUMA_FOUNDATION_CALLOUT }}"
             - name: INTERACTIVE_EXAMPLES_BASE
-              value: "{{ KUMA_INTERACTIVE_EXAMPLES_BASE }}"
+              value: "{{ INTERACTIVE_EXAMPLES_BASE_URL }}"
             - name: KUMASCRIPT_URL_TEMPLATE
               value: {{ KUMA_URL_TEMPLATE_FOR_KUMASCRIPT }}
             - name: LEGACY_HOSTS

--- a/apps/mdn/mdn-aws/k8s/kumascript.deploy.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kumascript.deploy.yaml.j2
@@ -20,6 +20,8 @@ spec:
           ports:
             - containerPort: {{ KUMASCRIPT_CONTAINER_PORT }}
           env:
+            - name: interactive_examples__base_url
+              value: {{ INTERACTIVE_EXAMPLES_BASE_URL }}
             - name: live_samples__base_url
               value: {{ KUMASCRIPT_LIVE_SAMPLES_BASE_URL }}
             - name: log__console

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.min.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.min.sh
@@ -117,7 +117,6 @@ export KUMA_ENABLE_CANDIDATE_LANGUAGES=False
 export KUMA_ES_INDEX_PREFIX=mdnprod
 export KUMA_ES_LIVE_INDEX=True
 export KUMA_FOUNDATION_CALLOUT=False
-export KUMA_INTERACTIVE_EXAMPLES_BASE=https://interactive-examples.mdn.mozit.cloud
 export KUMA_LEGACY_HOSTS="cdn.mdn.mozilla.net,developer.mozilla.com,mdn.mozilla.org,developer-new.mozilla.org,developers.mozilla.org"
 export KUMA_LEGACY_ROOT=/mdn/www
 export KUMA_MAINTENANCE_MODE=True
@@ -129,6 +128,8 @@ export KUMA_SERVE_LEGACY=True
 export KUMA_SESSION_COOKIE_SECURE=True
 export KUMA_STATIC_URL=https://developer-prod.mdn.mozit.cloud/static/
 export KUMA_WEB_CONCURRENCY=4
+
+export INTERACTIVE_EXAMPLES_BASE_URL=https://interactive-examples.mdn.mozit.cloud
 
 export SYNC_BUCKET=s3://mdn-shared-backup-c2037ed87dd96008
 export BACKUP_BUCKET=s3://mdn-shared-backup-c2037ed87dd96008

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.sh
@@ -116,7 +116,6 @@ export KUMA_ENABLE_CANDIDATE_LANGUAGES=False
 export KUMA_ES_INDEX_PREFIX=mdnprod
 export KUMA_ES_LIVE_INDEX=True
 export KUMA_FOUNDATION_CALLOUT=False
-export KUMA_INTERACTIVE_EXAMPLES_BASE=https://interactive-examples.mdn.mozit.cloud
 export KUMA_LEGACY_HOSTS="cdn.mdn.mozilla.net,developer.mozilla.com,mdn.mozilla.org,developer-new.mozilla.org,developers.mozilla.org"
 export KUMA_LEGACY_ROOT=/mdn/www
 export KUMA_MAINTENANCE_MODE=True
@@ -128,6 +127,8 @@ export KUMA_SERVE_LEGACY=True
 export KUMA_SESSION_COOKIE_SECURE=True
 export KUMA_STATIC_URL=https://developer-prod.mdn.mozit.cloud/static/
 export KUMA_WEB_CONCURRENCY=4
+
+export INTERACTIVE_EXAMPLES_BASE_URL=https://interactive-examples.mdn.mozit.cloud
 
 export SYNC_BUCKET=s3://mdn-shared-backup-c2037ed87dd96008
 export BACKUP_BUCKET=s3://mdn-shared-backup-c2037ed87dd96008


### PR DESCRIPTION
This PR is what #70 should have been. It allows the base URL for the interactive examples to be modified, but this time ensures that setting is communicated to Kumascript as well as Kuma.

This has already been deployed to the prod PoC instance and successfully tested.