### PR TITLE
add behavior for contribute endpoint to primary cdn

### DIFF
--- a/apps/mdn/mdn-aws/infra/mdn-cdn/cloudfront_primary/README.md
+++ b/apps/mdn/mdn-aws/infra/mdn-cdn/cloudfront_primary/README.md
@@ -28,7 +28,7 @@ files. The responses to these requests are cached for long periods of time
 separate CDN for the static/media assets.
 
 ## Pass-Through Behaviors
-Each of these behaviors, `#2` through `#13` as well as `#18` through `#22`, share the
+Each of these behaviors, `#2` through `#13` as well as `#18` through `#24`, share the
 same configuration except for the path pattern, and are designed to simply
 forward the complete incoming request to the origin (all headers, cookies,
 and query parameters), and perform **no** caching of the response. Most,

--- a/apps/mdn/mdn-aws/infra/mdn-cdn/cloudfront_primary/cloudfront.tf
+++ b/apps/mdn/mdn-aws/infra/mdn-cdn/cloudfront_primary/cloudfront.tf
@@ -581,6 +581,29 @@ resource "aws_cloudfront_distribution" "mdn-primary-cf-dist" {
 
   # 23
   ordered_cache_behavior {
+    path_pattern = "*/contribute"
+
+    allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    min_ttl                = 0
+    smooth_streaming       = false
+    target_origin_id       = "${var.distribution_name}"
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = true
+      headers = ["*"]
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  # 24
+  ordered_cache_behavior {
     path_pattern = "admin/*"
 
     allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]


### PR DESCRIPTION
This PR inserts the `*/contribute` behavior into the ordered list of behaviors for the primary CDN. This is a pass-through behavior, so nothing is cached and all headers and cookies are forwarded. In this case, we want to ensure that the CSRF token cookie is forwarded.

It terms of ordering, it must at least follow the behavior for `*/docs/*` (currently `#14`) so that it won't conflict with a current or future doc slug that ends with `/contribute`. 