### PR TITLE
bug 1483072: use TO_REVISION_HASH from env for reliability

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -299,7 +299,7 @@ k8s-delete-db-migration-job:
 k8s-kuma-record-deployment-job: k8s-kuma-delete-record-deployment-job
 	env APP_NAME=kuma \
 		FROM_REVISION_HASH=${FROM_REVISION_HASH} \
-		TO_REVISION_HASH=$(shell make k8s-get-kuma-revision-hash) \
+		TO_REVISION_HASH=${TO_REVISION_HASH} \
 		j2 mdn-record-deployment-job.yaml.j2 | ${KUBECTL} apply -n ${K8S_NAMESPACE} -f -
 	env JOB_NAME=mdn-kuma-record-deployment ./wait_for_job.sh
 
@@ -309,7 +309,7 @@ k8s-kuma-delete-record-deployment-job:
 k8s-kumascript-record-deployment-job: k8s-kumascript-delete-record-deployment-job
 	env APP_NAME=kumascript \
 		FROM_REVISION_HASH=${FROM_REVISION_HASH} \
-		TO_REVISION_HASH=$(shell make k8s-get-kumascript-revision-hash) \
+		TO_REVISION_HASH=${TO_REVISION_HASH} \
 		j2 mdn-record-deployment-job.yaml.j2 | ${KUBECTL} apply -n ${K8S_NAMESPACE} -f -
 	env JOB_NAME=mdn-kumascript-record-deployment ./wait_for_job.sh
 


### PR DESCRIPTION
We've seen an infrequent but annoying problem where the recording of a `kuma` or `kumascript` deployment within New Relic or SpeedCurve fails due to the calls to [`make k8s-get-kuma-revision-hash`](https://github.com/mdn/infra/blob/f5a88b782da205920acd4d0a6b351ae25634acc4/apps/mdn/mdn-aws/k8s/Makefile#L302) and [`k8s-get-kumascript-revision-hash`](https://github.com/mdn/infra/blob/f5a88b782da205920acd4d0a6b351ae25634acc4/apps/mdn/mdn-aws/k8s/Makefile#L312) within the deployment recording calls. This PR removes those calls, relying on the `TO_REVISION_HASH` being set from the environment. This PR depends on https://github.com/mozilla/kuma/pull/4990 and https://github.com/mdn/kumascript/pull/861, and should only be merged along with those PR's.