### PR TITLE
bug 1490727: Use live stripe API on production

### DIFF
--- a/apps/mdn/mdn-aws/k8s/regions/portland/prod.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/prod.sh
@@ -128,5 +128,5 @@ export KUMA_SECURE_HSTS_SECONDS=63072000
 export KUMA_SERVE_LEGACY=True
 export KUMA_SESSION_COOKIE_SECURE=True
 export KUMA_STATIC_URL=https://developer.mozilla.org/static/
-export KUMA_STRIPE_PUBLIC_KEY=pk_test_8QPCGoZzaushrXveHRqHAZch
+export KUMA_STRIPE_PUBLIC_KEY=pk_live_GZl4tCi8J5mWhKbJeRey4DSy
 export KUMA_WEB_CONCURRENCY=4


### PR DESCRIPTION
Switch to the live stripe API key in production. Testing can still happen on stage.