### PR TITLE
bug 1490727: add contrib_beta to stage/prod cdn cookie list

### DIFF
--- a/apps/mdn/mdn-aws/infra/modules/mdn-cdn/cloudfront_primary/cloudfront.tf
+++ b/apps/mdn/mdn-aws/infra/modules/mdn-cdn/cloudfront_primary/cloudfront.tf
@@ -387,7 +387,7 @@ resource "aws_cloudfront_distribution" "mdn-primary-cf-dist" {
 
       cookies {
         forward = "whitelist"
-        whitelisted_names = ["django_language", "dwf_sg_task_completion", "sessionid"]
+        whitelisted_names = ["django_language", "dwf_contrib_beta", "dwf_sg_task_completion", "sessionid"]
       }
     }
   }
@@ -642,7 +642,7 @@ resource "aws_cloudfront_distribution" "mdn-primary-cf-dist" {
 
       cookies {
         forward = "whitelist"
-        whitelisted_names = ["django_language", "dwf_sg_task_completion", "sessionid"]
+        whitelisted_names = ["django_language", "dwf_contrib_beta", "dwf_sg_task_completion", "sessionid"]
       }
     }
   }


### PR DESCRIPTION
This PR supports the contribution workflow by adding the `dwf_contrib_beta` cookie to the whitelist of cookie names for the primary `stage` and `prod` CDN's. This change has already been made and fully deployed on the primary `stage` and `prod` CDN's.