### PR TITLE
bug 1488281: Do not cache 400 responses

### DIFF
--- a/apps/mdn/mdn-aws/infra/modules/mdn-cdn/cloudfront_primary/cloudfront.tf
+++ b/apps/mdn/mdn-aws/infra/modules/mdn-cdn/cloudfront_primary/cloudfront.tf
@@ -20,6 +20,11 @@ resource "aws_cloudfront_distribution" "mdn-primary-cf-dist" {
 
   custom_error_response {
     error_caching_min_ttl = 0
+    error_code            = 400
+  }
+
+  custom_error_response {
+    error_caching_min_ttl = 0
     error_code            = 403
   }
 


### PR DESCRIPTION
``400 Bad Request`` responses are currently cached, but can cause issues if the cause of the 400 is not one of the Vary parameters, such as the requested host header.

I manually applied this change about a month ago (see [bug 1488281](https://bugzilla.mozilla.org/show_bug.cgi?id=1488281) for details), but held off on the PR until I could research if an integration test relied on cached 400 errors. We've run a few deployments since then, so I think we're OK.

