### PR TITLE
fix apiVersion in mdn-restore-cron.yaml.j2

### DIFF
--- a/apps/mdn/mdn-aws/k8s/mdn-restore-cron.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/mdn-restore-cron.yaml.j2
@@ -1,4 +1,4 @@
-apiVersion: batch/v2alpha1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: {{ RESTORE_SERVICE_NAME }}
@@ -51,4 +51,3 @@ spec:
               persistentVolumeClaim:
                 claimName: {{ SHARED_PVC_NAME }}
           restartPolicy: OnFailure
-


### PR DESCRIPTION
Fix the `apiVersion` in `apps/mdn/mdn-aws/k8s/mdn-restore-cron.yaml.j2`. The `batch/v2alpha1` version is no longer supported as of Kubernetes 1.8 (see https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/) and we're running 1.9.7.