### PR TITLE
use dockerhub mdnwebdocs/mdn-backup image

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -151,7 +151,7 @@ export SYNC_REMOTE_DIR ?= "/backups/efs/"
 
 export BACKUP_CONTAINER_NAME ?= mdn-backup
 export SYNC_FROM_S3_CONTAINER_NAME ?= mdn-sync
-export BACKUP_IMAGE ?= quay.io/mozmar/mdn-backup:6f73077
+export BACKUP_IMAGE ?= mdnwebdocs/mdn-backup:51ae821
 # cronjob syntax here: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/
 export BACKUP_SERVICE_SCHEDULE ?= "@hourly"
 export RESTORE_SERVICE_SCHEDULE ?= "@hourly"


### PR DESCRIPTION
Use the new DockerHub `mdnwebdocs/mdn-backup` image instead of the image on `quay.io`.