### PR TITLE
new cert and allowed hosts for standby

### DIFF
--- a/apps/mdn/mdn-aws/k8s/regions/germany/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/germany/prod.mm.sh
@@ -29,7 +29,7 @@ export WEB_SERVICE_TYPE=LoadBalancer
 export WEB_SERVICE_PORT=443
 export WEB_SERVICE_TARGET_PORT=8000
 export WEB_SERVICE_PROTOCOL=TCP
-export WEB_SERVICE_CERT_ARN=arn:aws:acm:eu-central-1:178589013767:certificate/1c74d68e-37a2-4b4c-93bf-fad17cff9ef9
+export WEB_SERVICE_CERT_ARN=arn:aws:acm:eu-central-1:178589013767:certificate/1a9fc27c-c161-449b-8b6f-09e9ffed3e77
 
 export API_SERVICE_NAME=api
 export API_SERVICE_TYPE=ClusterIP
@@ -51,7 +51,7 @@ export WEB_CPU_LIMIT=4
 export WEB_CPU_REQUEST=500m
 export WEB_MEMORY_LIMIT=8Gi
 export WEB_MEMORY_REQUEST=2Gi
-export WEB_ALLOWED_HOSTS="developer.mozilla.org,cdn.mdn.mozilla.net,mdn.mozillademos.org,demos.mdn.mozit.cloud,developer-prod.mdn.mozit.cloud,prod.mdn.mozit.cloud,developer.mozilla.com,mdn.mozilla.org,developer-new.mozilla.org,developers.mozilla.org"
+export WEB_ALLOWED_HOSTS="developer.mozilla.org,cdn.mdn.mozilla.net,mdn.mozillademos.org,demos.mdn.mozit.cloud,developer-prod.mdn.mozit.cloud,prod.mdn.mozit.cloud,standby.mdn.mozit.cloud,developer.mozilla.com,mdn.mozilla.org,developer-new.mozilla.org,developers.mozilla.org"
 
 export API_NAME=api
 export API_REPLICAS=1


### PR DESCRIPTION
This PR enables the standby instance to be used from the `standby.mdn.mozit.cloud` domain, updating the cert for the standby ELB, and adding `standby.mdn.mozit.cloud` to the allowed hosts.

This has already been used to deploy the K8s services and deployments to the standby cluster (https://standby.mdn.mozit.cloud/en-US/).

