### PR TITLE
add the rds backup as a weekly k8s cronjob

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -157,7 +157,13 @@ export BACKUP_SERVICE_SCHEDULE ?= "@hourly"
 export RESTORE_SERVICE_SCHEDULE ?= "@hourly"
 export SYNC_FROM_S3_SCHEDULE ?= "@hourly"
 
-
+export RDS_BACKUP_DIR ?= /backup
+export RDS_BACKUP_DBTYPE ?= MYSQL
+export RDS_BACKUP_DEBUG_MODE ?= false
+export RDS_BACKUP_IMAGE_TAG ?= d7d259b
+export RDS_BACKUP_IMAGE ?= mdnwebdocs/mdn-rds-backup
+export RDS_BACKUP_SCHEDULE ?= "@weekly"
+export RDS_BACKUP_BUCKET ?= s3://mdn-backup-bucket-0899eecc1f038f41/backups
 
 export FAILED_JOBS_HISTORY_LIMIT ?= 3
 export SUCCESSFUL_JOBS_HISTORY_LIMIT ?= 3
@@ -441,6 +447,12 @@ k8s-redis-dd: check-service-env
 k8s-delete-redis-dd: check-service-env
 	${KUBECTL} delete -n ${K8S_NAMESPACE} --ignore-not-found deployment ${DATADOG_REDIS_DEPLOYMENT_NAME}
 
+k8s-rds-backup-cron: check-service-env
+	j2 mdn-rds-backup-cron.yaml.j2 | ${KUBECTL} apply -n ${K8S_NAMESPACE} -f -
+
+k8s-delete-rds-backup-cron: check-service-env
+	${KUBECTL} delete -n ${K8S_NAMESPACE} --ignore-not-found cronjob mdn-rds-backup
+
 ### end administrative tasks
 ###############################
 
@@ -574,4 +586,5 @@ k8s-get-kumascript-revision-hash:
 		k8s-kuma-delete-record-deployment-job \
 		k8s-kumascript-delete-record-deployment-job \
 		k8s-get-kuma-revision-hash k8s-get-kumascript-revision-hash \
+		k8s-rds-backup-cron k8s-delete-rds-backup-cron \
 		check-service-env

--- a/apps/mdn/mdn-aws/k8s/mdn-rds-backup-cron.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/mdn-rds-backup-cron.yaml.j2
@@ -1,0 +1,73 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: mdn-rds-backup
+spec:
+  schedule: {{ RDS_BACKUP_SCHEDULE }}
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: {{ FAILED_JOBS_HISTORY_LIMIT }}
+  successfulJobsHistoryLimit: {{ SUCCESSFUL_JOBS_HISTORY_LIMIT }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: mdn-rds-backup
+              image: {{ RDS_BACKUP_IMAGE }}:{{ RDS_BACKUP_IMAGE_TAG }}
+              {%- if RDS_BACKUP_DEBUG_MODE == 'true' %}
+              command: [ "/bin/bash", "-c", "--" ]
+              args: [ "while true; do sleep 30; done;" ]
+              {%- endif %}
+              env:
+                - name: DBTYPE
+                  value: {{ RDS_BACKUP_DBTYPE }}
+                - name: BACKUP_DIR
+                  value: {{ RDS_BACKUP_DIR }}
+                - name: BACKUP_BUCKET
+                  value: {{ RDS_BACKUP_BUCKET }}
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: mdn-rds-backup-secrets
+                      key: access_key
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: mdn-rds-backup-secrets
+                      key: secret_key
+                - name: BACKUP_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: mdn-rds-backup-secrets
+                      key: BACKUP_PASSWORD
+                - name: DBHOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: mdn-rds-backup-secrets
+                      key: DBHOST
+                - name: DBNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: mdn-rds-backup-secrets
+                      key: DBNAME
+                - name: DBPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: mdn-rds-backup-secrets
+                      key: DBPASSWORD
+                - name: DBPORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: mdn-rds-backup-secrets
+                      key: DBPORT
+                - name: DBUSER
+                  valueFrom:
+                    secretKeyRef:
+                      name: mdn-rds-backup-secrets
+                      key: DBUSER
+                - name: DEADMANSSNITCH_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: mdn-rds-backup-secrets
+                      key: DEADMANSSNITCH_URL


### PR DESCRIPTION
This PR makes the RDS backups a Kubernetes `CronJob`, building on @metadave's [`rds_backup_tool`](https://github.com/mdn/infra/tree/master/tools/aws/rds_backup_tool) but with the luxury of running in a newer Kubernetes cluster that allows `CronJob`s. This PR has the RDS backups running on a weekly basis, but for testing purposes I've already deployed this to run on a daily basis (and have already run it once to ensure that the secrets were successfully consumed and that the RDS backup started successfully).

Requires https://github.com/mozilla/mdn-k8s-private/pull/79 (which, among other things, provides a valid Dead Man's Snitch URL in the MozIT account for monitoring purposes).