### PR TITLE
perform rds backups daily rather than weekly

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -162,7 +162,7 @@ export RDS_BACKUP_DBTYPE ?= MYSQL
 export RDS_BACKUP_DEBUG_MODE ?= false
 export RDS_BACKUP_IMAGE_TAG ?= d7d259b
 export RDS_BACKUP_IMAGE ?= mdnwebdocs/mdn-rds-backup
-export RDS_BACKUP_SCHEDULE ?= "@weekly"
+export RDS_BACKUP_SCHEDULE ?= "@daily"
 export RDS_BACKUP_BUCKET ?= s3://mdn-backup-bucket-0899eecc1f038f41/backups
 
 export FAILED_JOBS_HISTORY_LIMIT ?= 3


### PR DESCRIPTION
@metadave, @jgmize, and I decided we'd like to perform RDS backups on a daily rather than weekly basis. The `mdn-rds-backup` `CronJob` running in the MozIT standby cluster is already configured for daily backups, so this PR simply keeps the configuration up-to-date.