### PR TITLE
echo revision-hash env vars

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -303,9 +303,9 @@ k8s-delete-db-migration-job:
 	${KUBECTL} delete -n ${K8S_NAMESPACE} --ignore-not-found job mdn-db-migration
 
 k8s-kuma-record-deployment-job: k8s-kuma-delete-record-deployment-job
+	@ echo FROM_REVISION_HASH=${FROM_REVISION_HASH}
+	@ echo TO_REVISION_HASH=${TO_REVISION_HASH}
 	env APP_NAME=kuma \
-		FROM_REVISION_HASH=${FROM_REVISION_HASH} \
-		TO_REVISION_HASH=${TO_REVISION_HASH} \
 		j2 mdn-record-deployment-job.yaml.j2 | ${KUBECTL} apply -n ${K8S_NAMESPACE} -f -
 	env JOB_NAME=mdn-kuma-record-deployment ./wait_for_job.sh
 
@@ -313,9 +313,9 @@ k8s-kuma-delete-record-deployment-job:
 	${KUBECTL} delete -n ${K8S_NAMESPACE} --ignore-not-found job mdn-kuma-record-deployment
 
 k8s-kumascript-record-deployment-job: k8s-kumascript-delete-record-deployment-job
+	@ echo FROM_REVISION_HASH=${FROM_REVISION_HASH}
+	@ echo TO_REVISION_HASH=${TO_REVISION_HASH}
 	env APP_NAME=kumascript \
-		FROM_REVISION_HASH=${FROM_REVISION_HASH} \
-		TO_REVISION_HASH=${TO_REVISION_HASH} \
 		j2 mdn-record-deployment-job.yaml.j2 | ${KUBECTL} apply -n ${K8S_NAMESPACE} -f -
 	env JOB_NAME=mdn-kumascript-record-deployment ./wait_for_job.sh
 


### PR DESCRIPTION
I spent some time looking into the recent failures of the "record rollout" push step, but couldn't gain any new insights, so I'm trying this with the hope that it makes a difference. I'm removing the revision-hash definitions from the `env` command, since having them there seemed to enable the failure and because they were added solely for debugging purposes. Instead, I'm echoing the values prior to running the recording job.