### PR TITLE
Enable cloudfront logging

### DIFF
--- a/apps/mdn/mdn-aws/infra/modules/mdn-cdn/cloudfront_attachments/cloudfront_attachments.tf
+++ b/apps/mdn/mdn-aws/infra/modules/mdn-cdn/cloudfront_attachments/cloudfront_attachments.tf
@@ -1,13 +1,50 @@
-variable "distribution_name" {}
-variable "comment" {}
-variable "domain_name" {}
-variable "acm_cert_arn" {}
 
-variable "aliases" {
-  type = "list"
+locals {
+  log_bucket = "${var.distribution_name}-logs"
 }
 
-variable "enabled" {}
+resource "random_id" "rand-var" {
+  keepers = {
+    bucket_name = "${local.log_bucket}"
+  }
+
+  byte_length = 8
+}
+
+resource "aws_s3_bucket" "logging" {
+  bucket = "${local.log_bucket}-${random_id.rand-var.hex}"
+  acl    = "log-delivery-write"
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    enabled = true
+
+    transition {
+      days          = "${var.standard_transition_days}"
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days  = "${var.glacier_transition_days}"
+      storage_class = "GLACIER"
+    }
+
+    expiration {
+      days = "${var.expiration_days}"
+    }
+  }
+
+  tags {
+    Name        = "${local.log_bucket}-${random_id.rand-var.hex}"
+    Environment = "${var.environment}"
+    Service     = "MDN"
+    Purpose     = "Cloudfront logging bucket"
+  }
+
+}
 
 resource "aws_cloudfront_distribution" "mdn-attachments-cf-dist" {
   count           = "${var.enabled}"
@@ -17,6 +54,12 @@ resource "aws_cloudfront_distribution" "mdn-attachments-cf-dist" {
   http_version    = "http2"
   is_ipv6_enabled = false
   price_class     = "PriceClass_All"
+
+  logging_config {
+    include_cookies = "${var.cloudfront_log_cookies}"
+    bucket          = "${aws_s3_bucket.logging.bucket_domain_name}"
+    prefix          = "${var.cloudfront_log_prefix}"
+  }
 
   custom_error_response {
     error_caching_min_ttl = 300
@@ -72,5 +115,12 @@ resource "aws_cloudfront_distribution" "mdn-attachments-cf-dist" {
 
     # https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html#minimum_protocol_version
     minimum_protocol_version = "TLSv1"
+  }
+
+  tags {
+    Name        = "${var.distribution_name}"
+    Environment = "${var.environment}"
+    Purpose     = "Attachment CDN"
+    Service     = "MDN"
   }
 }

--- a/apps/mdn/mdn-aws/infra/modules/mdn-cdn/cloudfront_attachments/inputs.tf
+++ b/apps/mdn/mdn-aws/infra/modules/mdn-cdn/cloudfront_attachments/inputs.tf
@@ -1,0 +1,30 @@
+variable "enabled" {}
+variable "distribution_name" {}
+variable "environment" {}
+variable "comment" {}
+variable "domain_name" {}
+variable "acm_cert_arn" {}
+
+variable "aliases" {
+  type = "list"
+}
+
+variable "standard_transition_days" {
+  default = "60"
+}
+
+variable "glacier_transition_days" {
+  default = "90"
+}
+
+variable "expiration_days" {
+  default = "180"
+}
+
+variable "cloudfront_log_cookies" {
+  default = false
+}
+
+variable "cloudfront_log_prefix" {
+  default = ""
+}

--- a/apps/mdn/mdn-aws/infra/modules/mdn-cdn/cloudfront_primary/inputs.tf
+++ b/apps/mdn/mdn-aws/infra/modules/mdn-cdn/cloudfront_primary/inputs.tf
@@ -1,0 +1,30 @@
+variable "enabled" {}
+variable "environment" {}
+variable "distribution_name" {}
+variable "comment" {}
+variable "domain_name" {}
+variable "acm_cert_arn" {}
+
+variable "aliases" {
+  type = "list"
+}
+
+variable "standard_transition_days" {
+  default = "60"
+}
+
+variable "glacier_transition_days" {
+  default = "90"
+}
+
+variable "expiration_days" {
+  default = "180"
+}
+
+variable "cloudfront_log_cookies" {
+  default = false
+}
+
+variable "cloudfront_log_prefix" {
+  default = ""
+}

--- a/apps/mdn/mdn-aws/infra/modules/mdn-cdn/mdn_cdn.tf
+++ b/apps/mdn/mdn-aws/infra/modules/mdn-cdn/mdn_cdn.tf
@@ -10,6 +10,7 @@ module "primary-cloudfront" {
   source            = "./cloudfront_primary"
   enabled           = "${var.enabled * var.cloudfront_primary_enabled}"
   distribution_name = "${var.cloudfront_primary_distribution_name}-${var.environment}"
+  environment       = "${var.environment}"
   comment           = "MDN Primary ${var.environment} CDN"
   acm_cert_arn      = "${var.acm_primary_cert_arn}"
   aliases           = [ "${var.cloudfront_primary_aliases}" ]
@@ -23,6 +24,7 @@ module "primary-cloudfront" {
 module "cloudfront-attachments" {
   source            = "./cloudfront_attachments"
   enabled           = "${var.enabled * var.cloudfront_attachments_enabled}"
+  environment       = "${var.environment}"
   distribution_name = "${var.cloudfront_attachments_distribution_name}-${var.environment}"
   comment           = "MDN ${var.environment} Attachments CDN"
   acm_cert_arn      = "${var.acm_attachments_cert_arn}"


### PR DESCRIPTION
Get the primary and attachment CDN's logging to S3, also sneaked in some fixes to get the cloudfront distribution tagged.

The tags should help with datadog graphing in the future. Fixes #100