### PR TITLE
use mdn-admin image on dockerhub

### DIFF
--- a/apps/mdn/mdn-aws/k8s/mdn-admin-node.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/mdn-admin-node.yaml.j2
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: {{ ADMIN_NODE_NAME }}
-          image: mysql
+          image: mdnwebdocs/mdn-admin:e4ff5ba
           command: [ "/bin/bash", "-c", "--" ]
           args: [ "while true; do sleep 30; done;" ]
           volumeMounts:


### PR DESCRIPTION
This PR changes the admin node to use the `mdnwebdocs/mdn-admin` DockerHub image that @limed recently added with https://github.com/mdn/infra/pull/106.