### PR TITLE
add EFS to/from S3 sync K8s jobs

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -453,6 +453,18 @@ k8s-rds-backup-cron: check-service-env
 k8s-delete-rds-backup-cron: check-service-env
 	${KUBECTL} delete -n ${K8S_NAMESPACE} --ignore-not-found cronjob mdn-rds-backup
 
+# one-time job to push EFS to S3
+k8s-sync-efs-to-s3-job: check-service-env
+	env PUSH_OR_PULL=PUSH \
+		JOB_NAME=mdn-sync-efs-to-s3 \
+		j2 mdn-sync-efs-job.yaml.j2 | ${KUBECTL} apply -n ${K8S_NAMESPACE} -f -
+
+# one-time job to load EFS from S3
+k8s-sync-efs-from-s3-job: check-service-env
+	env PUSH_OR_PULL=PULL \
+		JOB_NAME=mdn-sync-efs-from-s3 \
+		j2 mdn-sync-efs-job.yaml.j2 | ${KUBECTL} apply -n ${K8S_NAMESPACE} -f -
+
 ### end administrative tasks
 ###############################
 

--- a/apps/mdn/mdn-aws/k8s/mdn-sync-efs-job.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/mdn-sync-efs-job.yaml.j2
@@ -1,0 +1,44 @@
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: {{ JOB_NAME }}
+spec:
+  template:
+    metadata:
+      name: {{ JOB_NAME }}
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: {{ JOB_NAME }}
+          image: {{ BACKUP_IMAGE }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: {{ BACKUP_MOUNT_DIR }}
+              name: {{ SHARED_PVC_NAME }}
+          env:
+            - name: LOCAL_DIR
+              value: {{ BACKUP_LOCAL_DIR }}
+            - name: REMOTE_DIR
+              value: {{ BACKUP_REMOTE_DIR }}
+            - name: BUCKET
+              value: "{{ BACKUP_BUCKET }}"
+            - name: PUSH_OR_PULL
+              value: {{ PUSH_OR_PULL }}
+            - name: AWS_REGION
+              value: "{{ AWS_BACKUP_REGION }}"
+            - name: AWS_S3SYNC_PAGE_SIZE
+              value: "{{ AWS_BACKUP_PAGE_SIZE }}"
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ BACKUP_SECRETS_NAME }}
+                  key: access_key
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ BACKUP_SECRETS_NAME }}
+                  key: secret_key
+      volumes:
+        - name: {{ SHARED_PVC_NAME }}
+          persistentVolumeClaim:
+            claimName: {{ SHARED_PVC_NAME }}


### PR DESCRIPTION
This PR addresses both #107 and #108, providing simple `Makefile` targets, where each runs a K8s Job to sync EFS to/from S3. These `Makefile` targets will be used during the `Copy EFS content from MozMEAO --> MozIT` portion of the cutover process. For example:
```sh
# Assumes you are within the infra repo 
# Sync MozMEAO EFS to MozMEAO S3
source regions/portland/prod.sh
make k8s-sync-efs-to-s3-job
# Copy MozMEAO S3 to MozIT S3
aws-vault exec --assume-role-ttl 1h mozilla-mdn-admin -- aws s3 sync --exclude "logs/*" s3://mdn-shared-backup s3://mdn-shared-backup-c2037ed87dd96008
# Sync MozIT S3 to MozIT EFS
source regions/oregon/prod.sh
make k8s-sync-efs-from-s3-job
```