### PR TITLE
give admin node access to mdn-admin-node-secrets resource

### DIFF
--- a/apps/mdn/mdn-aws/k8s/mdn-admin-node.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/mdn-admin-node.yaml.j2
@@ -17,6 +17,17 @@ spec:
           volumeMounts:
             - mountPath: {{ BACKUP_MOUNT_DIR }}
               name: {{ SHARED_PVC_NAME }}
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: mdn-admin-node-secrets
+                  key: access_key
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mdn-admin-node-secrets
+                  key: secret_key
       volumes:
         - name: {{ SHARED_PVC_NAME }}
           persistentVolumeClaim:


### PR DESCRIPTION
This PR adds AWS credentials for the `mdn-admin-node-user` to the MDN admin node. That user is currently configured with read access to the S3 buckets for EFS and RDS backups. The `mdn-admin-node-secrets` have already been deployed within the `oregon` and `germany` clusters.