### PR TITLE
use better names for the RDS and EFS backup buckets

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -166,7 +166,7 @@ export RDS_BACKUP_DEBUG_MODE ?= false
 export RDS_BACKUP_IMAGE_TAG ?= d7d259b
 export RDS_BACKUP_IMAGE ?= mdnwebdocs/mdn-rds-backup
 export RDS_BACKUP_SCHEDULE ?= "@daily"
-export RDS_BACKUP_BUCKET ?= s3://mdn-backup-bucket-0899eecc1f038f41/backups
+export RDS_BACKUP_BUCKET ?= s3://mdn-rds-backup-7752d5ca6f3744a0/backups
 
 export FAILED_JOBS_HISTORY_LIMIT ?= 3
 export SUCCESSFUL_JOBS_HISTORY_LIMIT ?= 3

--- a/apps/mdn/mdn-aws/k8s/regions/germany/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/germany/prod.mm.sh
@@ -133,5 +133,5 @@ export KUMA_WEB_CONCURRENCY=4
 
 export INTERACTIVE_EXAMPLES_BASE_URL=https://interactive-examples.mdn.mozilla.net
 
-export SYNC_BUCKET=s3://mdn-shared-backup-c2037ed87dd96008
-export BACKUP_BUCKET=s3://mdn-shared-backup-c2037ed87dd96008
+export SYNC_BUCKET=s3://mdn-efs-backup-c2037ed87dd96008
+export BACKUP_BUCKET=s3://mdn-efs-backup-c2037ed87dd96008

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.sh
@@ -133,5 +133,5 @@ export KUMA_WEB_CONCURRENCY=4
 
 export INTERACTIVE_EXAMPLES_BASE_URL=https://interactive-examples.mdn.mozilla.net
 
-export SYNC_BUCKET=s3://mdn-shared-backup-c2037ed87dd96008
-export BACKUP_BUCKET=s3://mdn-shared-backup-c2037ed87dd96008
+export SYNC_BUCKET=s3://mdn-efs-backup-c2037ed87dd96008
+export BACKUP_BUCKET=s3://mdn-efs-backup-c2037ed87dd96008

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/prod.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/prod.sh
@@ -133,5 +133,5 @@ export KUMA_WEB_CONCURRENCY=4
 
 export INTERACTIVE_EXAMPLES_BASE_URL=https://interactive-examples.mdn.mozilla.net
 
-export SYNC_BUCKET=s3://mdn-shared-backup-c2037ed87dd96008
-export BACKUP_BUCKET=s3://mdn-shared-backup-c2037ed87dd96008
+export SYNC_BUCKET=s3://mdn-efs-backup-c2037ed87dd96008
+export BACKUP_BUCKET=s3://mdn-efs-backup-c2037ed87dd96008

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/stage.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/stage.mm.sh
@@ -133,5 +133,5 @@ export KUMA_WEB_CONCURRENCY=4
 
 export INTERACTIVE_EXAMPLES_BASE_URL=https://interactive-examples.mdn.mozilla.net
 
-export SYNC_BUCKET=s3://mdn-shared-backup-c2037ed87dd96008
-export BACKUP_BUCKET=s3://mdn-shared-backup-c2037ed87dd96008
+export SYNC_BUCKET=s3://mdn-efs-backup-c2037ed87dd96008
+export BACKUP_BUCKET=s3://mdn-efs-backup-c2037ed87dd96008

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
@@ -136,5 +136,5 @@ export KUMA_WEB_CONCURRENCY=4
 
 export INTERACTIVE_EXAMPLES_BASE_URL=https://interactive-examples.mdn.mozilla.net
 
-export SYNC_BUCKET=s3://mdn-shared-backup-c2037ed87dd96008
-export BACKUP_BUCKET=s3://mdn-shared-backup-c2037ed87dd96008
+export SYNC_BUCKET=s3://mdn-efs-backup-c2037ed87dd96008
+export BACKUP_BUCKET=s3://mdn-efs-backup-c2037ed87dd96008

--- a/apps/mdn/utils/mdn_backup_cron/README.md
+++ b/apps/mdn/utils/mdn_backup_cron/README.md
@@ -13,7 +13,7 @@ The default target will build and push the image to quay.io.
 ## Configuration
 
 - `LOCAL_DIR` - the directory *in the running container* that we'll push or pull from.
-- `BUCKET` - the bucket where backup data is stored. 
+- `BUCKET` - the bucket where backup data is stored.
 - `REMOTE_DIR` - the directory in `$BUCKET` that we'll push or pull from.
 - `PUSH_OR_PULL` - set to either `PUSH` or `PULL`
   - `PUSH` - recursively sync from `$LOCAL_DIR` to `$BUCKET$REMOTE_DIR`
@@ -56,7 +56,7 @@ docker run \
         -e PUSH_OR_PULL="PULL" \
         -e LOCAL_DIR="/mdn_stuff" \
         -e REMOTE_DIR="/backups/www" \
-        -e BUCKET="s3://mdn-shared-backup" \
+        -e BUCKET="s3://mdn-efs-backup" \
         -v $(pwd)/stuff:/mdn_stuff \
         quay.io/mozmar/mdn-backup:latest
 ```

--- a/apps/mdn/utils/mdn_backup_cron/image/Dockerfile
+++ b/apps/mdn/utils/mdn_backup_cron/image/Dockerfile
@@ -4,7 +4,7 @@ ENV AWS_ACCESS_KEY_ID setme
 ENV AWS_SECRET_ACCESS_KEY setme
 ENV LOCAL_DIR /data
 ENV REMOTE_DIR /backups/
-ENV BUCKET s3://mdn-shared-backup
+ENV BUCKET s3://mdn-efs-backup
 
 # set to either PUSH or PULL
 ENV PUSH_OR_PULL PUSH


### PR DESCRIPTION
This PR uses the new and improved names for the RDS and EFS backup S3 buckets.