### PR TITLE
Remove acm cert, we manually create interactive-example certs

### DIFF
--- a/apps/mdn/mdn-aws/infra/acm.tf
+++ b/apps/mdn/mdn-aws/infra/acm.tf
@@ -18,17 +18,6 @@ module "acm_star_mdn" {
   zone_id     = "${data.terraform_remote_state.dns.master-zone}"
 }
 
-module "interactive-example-acm" {
-  source = "./modules/acm"
-
-  providers = {
-    aws = "aws.acm"
-  }
-
-  domain_name = "interactive-examples.mdn.mozit.cloud"
-  zone_id     = "${data.terraform_remote_state.dns.master-zone}"
-}
-
 module "acm_ci" {
   source = "./modules/acm"
 


### PR DESCRIPTION
Removing interactive-examples cert we create those by hand so removing this to make sure there are no conflicts