### PR TITLE
switch MozMEAO from quay.io to DockerHub

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -81,14 +81,14 @@ export CELERY_CAM_MEMORY_REQUEST ?= 256Mi
 export KUMASCRIPT_NAME ?= kumascript
 export KUMASCRIPT_REPLICAS ?= 1
 export KUMASCRIPT_CONTAINER_PORT ?= ${KUMASCRIPT_SERVICE_TARGET_PORT}
-export KUMASCRIPT_IMAGE ?= quay.io/mozmar/kumascript
+export KUMASCRIPT_IMAGE ?= mdnwebdocs/kumascript
 export KUMASCRIPT_IMAGE_PULL_POLICY ?= IfNotPresent
 export KUMASCRIPT_CPU_LIMIT ?= 2
 export KUMASCRIPT_CPU_REQUEST ?= 100m
 export KUMASCRIPT_MEMORY_LIMIT ?= 4Gi
 export KUMASCRIPT_MEMORY_REQUEST ?= 256Mi
 
-export KUMA_IMAGE ?= quay.io/mozmar/kuma
+export KUMA_IMAGE ?= mdnwebdocs/kuma
 export KUMA_IMAGE_PULL_POLICY ?= IfNotPresent
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.
 export KUMA_MOUNT_PATH ?= /mdn

--- a/apps/mdn/mdn-aws/k8s/README.md
+++ b/apps/mdn/mdn-aws/k8s/README.md
@@ -45,9 +45,9 @@ brew install jq
 
 #### Deploying MDN with Kuma updates only
 
-- Specify the Kuma image tag you want to deploy. It must be available from quay.io (see https://quay.io/repository/mozmar/kuma?tab=tags for a list of available tags). New Kuma images are built and registered on quay.io after every commit to the `master` branch of https://github.com/mozilla/kuma.
+- Specify the Kuma image tag you want to deploy. It must be available from DockerHub (see https://hub.docker.com/r/mdnwebdocs/kuma/tags/ for a list of available tags). New Kuma images are built and registered on DockerHub after every commit to the `master` branch of https://github.com/mozilla/kuma.
 ```sh
-export KUMA_IMAGE_TAG=<tag-from-quay.io>
+export KUMA_IMAGE_TAG=<tag-from-dockerhub>
 ```
 
 - Run the database migrations
@@ -72,9 +72,9 @@ make k8s-kuma-rollback
 
 #### Deploying MDN with Kumascript updates only
 
-- Specify the Kumascript image tag you want to deploy. It must be available from quay.io (see https://quay.io/repository/mozmar/kumascript?tab=tags for a list of available tags). New Kumascript images are built and registered on quay.io after every commit to the `master` branch of https://github.com/mdn/kumascript.
+- Specify the Kumascript image tag you want to deploy. It must be available from DockerHub (see https://hub.docker.com/r/mdnwebdocs/kumascript/tags/ for a list of available tags). New Kumascript images are built and registered on DockerHub after every commit to the `master` branch of https://github.com/mdn/kumascript.
 ```sh
-export KUMASCRIPT_IMAGE_TAG=<tag-from-quay.io>
+export KUMASCRIPT_IMAGE_TAG=<tag-from-dockerhub>
 ```
 
 - Rollout the update
@@ -96,8 +96,8 @@ make k8s-kumascript-rollback
 
 - Specify the Kuma and Kumascript image tags you want to deploy.
 ```sh
-export KUMA_IMAGE_TAG=<tag-from-quay.io>
-export KUMASCRIPT_IMAGE_TAG=<tag-from-quay.io>
+export KUMA_IMAGE_TAG=<tag-from-dockerhub>
+export KUMASCRIPT_IMAGE_TAG=<tag-from-dockerhub>
 ```
 
 - Run the database migrations

--- a/apps/mdn/mdn-aws/k8s/regions/frankfurt/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/frankfurt/prod.mm.sh
@@ -88,14 +88,14 @@ export CELERY_CAM_MEMORY_REQUEST=1Gi
 export KUMASCRIPT_NAME=kumascript
 export KUMASCRIPT_REPLICAS=1
 export KUMASCRIPT_CONTAINER_PORT=${KUMASCRIPT_SERVICE_TARGET_PORT}
-export KUMASCRIPT_IMAGE=quay.io/mozmar/kumascript
+export KUMASCRIPT_IMAGE=mdnwebdocs/kumascript
 export KUMASCRIPT_IMAGE_PULL_POLICY=IfNotPresent
 export KUMASCRIPT_CPU_LIMIT=4
 export KUMASCRIPT_CPU_REQUEST=500m
 export KUMASCRIPT_MEMORY_LIMIT=8Gi
 export KUMASCRIPT_MEMORY_REQUEST=2Gi
 
-export KUMA_IMAGE=quay.io/mozmar/kuma
+export KUMA_IMAGE=mdnwebdocs/kuma
 export KUMA_IMAGE_PULL_POLICY=IfNotPresent
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.
 export KUMA_MOUNT_PATH=/mdn

--- a/apps/mdn/mdn-aws/k8s/regions/portland/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/prod.mm.sh
@@ -88,14 +88,14 @@ export CELERY_CAM_MEMORY_REQUEST=1Gi
 export KUMASCRIPT_NAME=kumascript
 export KUMASCRIPT_REPLICAS=6
 export KUMASCRIPT_CONTAINER_PORT=${KUMASCRIPT_SERVICE_TARGET_PORT}
-export KUMASCRIPT_IMAGE=quay.io/mozmar/kumascript
+export KUMASCRIPT_IMAGE=mdnwebdocs/kumascript
 export KUMASCRIPT_IMAGE_PULL_POLICY=IfNotPresent
 export KUMASCRIPT_CPU_LIMIT=4
 export KUMASCRIPT_CPU_REQUEST=500m
 export KUMASCRIPT_MEMORY_LIMIT=8Gi
 export KUMASCRIPT_MEMORY_REQUEST=2Gi
 
-export KUMA_IMAGE=quay.io/mozmar/kuma
+export KUMA_IMAGE=mdnwebdocs/kuma
 export KUMA_IMAGE_PULL_POLICY=IfNotPresent
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.
 export KUMA_MOUNT_PATH=/mdn

--- a/apps/mdn/mdn-aws/k8s/regions/portland/prod.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/prod.sh
@@ -88,14 +88,14 @@ export CELERY_CAM_MEMORY_REQUEST=1Gi
 export KUMASCRIPT_NAME=kumascript
 export KUMASCRIPT_REPLICAS=6
 export KUMASCRIPT_CONTAINER_PORT=${KUMASCRIPT_SERVICE_TARGET_PORT}
-export KUMASCRIPT_IMAGE=quay.io/mozmar/kumascript
+export KUMASCRIPT_IMAGE=mdnwebdocs/kumascript
 export KUMASCRIPT_IMAGE_PULL_POLICY=IfNotPresent
 export KUMASCRIPT_CPU_LIMIT=4
 export KUMASCRIPT_CPU_REQUEST=500m
 export KUMASCRIPT_MEMORY_LIMIT=8Gi
 export KUMASCRIPT_MEMORY_REQUEST=2Gi
 
-export KUMA_IMAGE=quay.io/mozmar/kuma
+export KUMA_IMAGE=mdnwebdocs/kuma
 export KUMA_IMAGE_PULL_POLICY=IfNotPresent
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.
 export KUMA_MOUNT_PATH=/mdn

--- a/apps/mdn/mdn-aws/k8s/regions/portland/stage.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/stage.mm.sh
@@ -89,14 +89,14 @@ export CELERY_CAM_MEMORY_REQUEST=256Mi
 export KUMASCRIPT_NAME=kumascript
 export KUMASCRIPT_REPLICAS=1
 export KUMASCRIPT_CONTAINER_PORT=${KUMASCRIPT_SERVICE_TARGET_PORT}
-export KUMASCRIPT_IMAGE=quay.io/mozmar/kumascript
+export KUMASCRIPT_IMAGE=mdnwebdocs/kumascript
 export KUMASCRIPT_IMAGE_PULL_POLICY=IfNotPresent
 export KUMASCRIPT_CPU_LIMIT=2
 export KUMASCRIPT_CPU_REQUEST=100m
 export KUMASCRIPT_MEMORY_LIMIT=4Gi
 export KUMASCRIPT_MEMORY_REQUEST=256Mi
 
-export KUMA_IMAGE=quay.io/mozmar/kuma
+export KUMA_IMAGE=mdnwebdocs/kuma
 export KUMA_IMAGE_PULL_POLICY=IfNotPresent
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.
 export KUMA_MOUNT_PATH=/mdn

--- a/apps/mdn/mdn-aws/k8s/regions/portland/stage.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/portland/stage.sh
@@ -88,14 +88,14 @@ export CELERY_CAM_MEMORY_REQUEST=256Mi
 export KUMASCRIPT_NAME=kumascript
 export KUMASCRIPT_REPLICAS=1
 export KUMASCRIPT_CONTAINER_PORT=${KUMASCRIPT_SERVICE_TARGET_PORT}
-export KUMASCRIPT_IMAGE=quay.io/mozmar/kumascript
+export KUMASCRIPT_IMAGE=mdnwebdocs/kumascript
 export KUMASCRIPT_IMAGE_PULL_POLICY=IfNotPresent
 export KUMASCRIPT_CPU_LIMIT=2
 export KUMASCRIPT_CPU_REQUEST=100m
 export KUMASCRIPT_MEMORY_LIMIT=4Gi
 export KUMASCRIPT_MEMORY_REQUEST=256Mi
 
-export KUMA_IMAGE=quay.io/mozmar/kuma
+export KUMA_IMAGE=mdnwebdocs/kuma
 export KUMA_IMAGE_PULL_POLICY=IfNotPresent
 # "KUMA_MOUNT_PATH" sets the mount path for the claim of the shared volume.
 export KUMA_MOUNT_PATH=/mdn


### PR DESCRIPTION
Now that we're using DockerHub only for the Kuma and Kumascript Docker images, this PR reflects that change for the MozMEAO-related configuration files.