### PR TITLE
use admin node image with LANG=C.UTF-8

### DIFF
--- a/apps/mdn/mdn-aws/k8s/mdn-admin-node.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/mdn-admin-node.yaml.j2
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: {{ ADMIN_NODE_NAME }}
-          image: mdnwebdocs/mdn-admin:e4ff5ba
+          image: mdnwebdocs/mdn-admin:2f6c560
           command: [ "/bin/bash", "-c", "--" ]
           args: [ "while true; do sleep 30; done;" ]
           volumeMounts:


### PR DESCRIPTION
Update the admin node deployment to use the image built with `LANG=C.UTF-8`. This, for example,  avoids decoding errors when copying file attachments from S3 to EFS with filenames containing non-ASCII characters.