### PR TITLE
update apiVersion for EFS backup CronJob

### DIFF
--- a/apps/mdn/mdn-aws/k8s/mdn-backup-cron.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/mdn-backup-cron.yaml.j2
@@ -1,4 +1,4 @@
-apiVersion: batch/v2alpha1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: {{ BACKUP_SERVICE_NAME }}
@@ -51,4 +51,3 @@ spec:
               persistentVolumeClaim:
                 claimName: {{ SHARED_PVC_NAME }}
           restartPolicy: OnFailure
-


### PR DESCRIPTION
Just a simple fix that updates the `apiVersion` of the `mdn-backup-cron`. I discovered this issue during the cut-over today. It has already been deployed.