### PR TITLE
bug 948151: Use Sentry CSP reporter

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -103,6 +103,7 @@ export KUMA_CSRF_COOKIE_SECURE ?= True
 export KUMA_CSP_ENABLE_MIDDLEWARE ?= False
 export KUMA_CSP_REPORT_ENABLE ?= False
 export KUMA_CSP_REPORT_ONLY ?= True
+export KUMA_CSP_REPORT_URI ?= /csp-violation-capture
 export KUMA_DEBUG ?= False
 export KUMA_DEBUG_TOOLBAR ?= False
 export KUMA_DOMAIN ?= mdn-dev.moz.works

--- a/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
@@ -55,6 +55,8 @@
               value: "{{ KUMA_CSP_REPORT_ENABLE }}"
             - name: CSP_REPORT_ONLY
               value: "{{ KUMA_CSP_REPORT_ONLY }}"
+            - name: CSP_REPORT_URI
+              value: "{{ KUMA_CSP_REPORT_URI }}"
             - name: CSRF_COOKIE_SECURE
               value: "{{ KUMA_CSRF_COOKIE_SECURE }}"
             - name: DATABASE_URL

--- a/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
@@ -156,6 +156,8 @@
                 secretKeyRef:
                   name: mdn-secrets
                   key: sentry-dsn
+            - name: SENTRY_ENVIRONMENT
+              value: "{{ K8S_CLUSTER_SHORT_NAME }}:{{ TARGET_ENVIRONMENT }}"
             - name: SERVE_LEGACY
               value: "{{ KUMA_SERVE_LEGACY }}"
             - name: SERVER_EMAIL

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
@@ -110,6 +110,7 @@ export KUMA_CELERYD_MAX_TASKS_PER_CHILD=0
 export KUMA_CSP_ENABLE_MIDDLEWARE=True
 export KUMA_CSP_REPORT_ENABLE=True
 export KUMA_CSP_REPORT_ONLY=True
+export KUMA_CSP_REPORT_URI=https://sentry.prod.mozaws.net/api/72/security/?sentry_key=25e652a045b642dfaa310e92e800058a
 export KUMA_CSRF_COOKIE_SECURE=True
 export KUMA_DEBUG=False
 export KUMA_DEBUG_TOOLBAR=False


### PR DESCRIPTION
Use Sentry's CSP report endpoint rather than forwarding as a custom message. The UI in Sentry looks good:

https://blog.sentry.io/2018/09/20/content-security-policy-newegg-breach

Docs:

https://docs.sentry.io/learn/security-policy-reporting/