### PR TITLE
update cnames for interactive-examples cdn

### DIFF
--- a/apps/mdn/interactive-examples/setup.sh
+++ b/apps/mdn/interactive-examples/setup.sh
@@ -5,9 +5,8 @@ source ../bin/common.sh
 check_neres_env
 
 neres add-monitor "MDN interactive-examples" \
-    https://interactive-examples.mdn.moz.works \
+    https://interactive-examples.mdn.mozit.cloud \
     --location AWS_US_WEST_2 \
     --frequency 5 \
     --email "${NERES_EMAIL_1}" \
     --email "${NERES_EMAIL_2}"
-

--- a/apps/mdn/interactive-examples/tf/mdninteractive.tf
+++ b/apps/mdn/interactive-examples/tf/mdninteractive.tf
@@ -98,9 +98,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   }
 
   aliases = [
-    # FIXME: public name is taken by MozMeao account
-    # cloudfront complains about CNAMEAlreadyExists
-    #"interactive-examples.mdn.mozilla.net",
+    "interactive-examples.mdn.mozilla.net",
     "interactive-examples.mdn.mozit.cloud",
   ]
 


### PR DESCRIPTION
Adds `interactive-examples.mdn.mozilla.net` (the production domain) to the list of `CNAME`s for the Terraform for the interactive-examples CDN.