### PR TITLE
bug 1490727: Add STRIPE_PRODUCT_ID

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -121,6 +121,7 @@ export KUMA_SECURE_HSTS_SECONDS ?= 0
 export KUMA_SERVE_LEGACY ?= True
 export KUMA_SESSION_COOKIE_SECURE ?= True
 export KUMA_STATIC_URL ?= /static/
+export KUMA_STRIPE_PRODUCT_ID ?= ""
 export KUMA_STRIPE_PUBLIC_KEY ?= ""
 export KUMA_WEB_CONCURRENCY ?= 4
 

--- a/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
@@ -171,6 +171,8 @@
               value: {{ KUMA_PROTOCOL }}{{ KUMA_DOMAIN }}
             - name: STATIC_URL
               value: {{ KUMA_STATIC_URL }}
+            - name: STRIPE_PRODUCT_ID
+              value: {{ KUMA_STRIPE_PRODUCT_ID }}
             - name: STRIPE_PUBLIC_KEY
               value: {{ KUMA_STRIPE_PUBLIC_KEY }}
             - name: STRIPE_SECRET_KEY

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
@@ -132,6 +132,7 @@ export KUMA_SECURE_HSTS_SECONDS=63072000
 export KUMA_SERVE_LEGACY=True
 export KUMA_SESSION_COOKIE_SECURE=True
 export KUMA_STATIC_URL=https://developer.allizom.org/static/
+export KUMA_STRIPE_PRODUCT_ID=prod_test
 export KUMA_STRIPE_PUBLIC_KEY=pk_test_8QPCGoZzaushrXveHRqHAZch
 export KUMA_WEB_CONCURRENCY=4
 


### PR DESCRIPTION
This string is used as the ID for the service that is being purchased by signing up for recurring monthly payments.

I've created the ``prod_test`` product on the Stripe side. This is needed to deploy https://github.com/mozilla/kuma/pull/5061.