### PR TITLE
bug 948151: Enforce CSP in staging

### DIFF
--- a/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
@@ -109,7 +109,7 @@ export KUMA_CELERY_ALWAYS_EAGER=False
 export KUMA_CELERYD_MAX_TASKS_PER_CHILD=0
 export KUMA_CSP_ENABLE_MIDDLEWARE=True
 export KUMA_CSP_REPORT_ENABLE=True
-export KUMA_CSP_REPORT_ONLY=True
+export KUMA_CSP_REPORT_ONLY=False
 export KUMA_CSP_REPORT_URI=https://sentry.prod.mozaws.net/api/72/security/?sentry_key=25e652a045b642dfaa310e92e800058a
 export KUMA_CSRF_COOKIE_SECURE=True
 export KUMA_DEBUG=False


### PR DESCRIPTION
Let's see what breaks when we enforce CSP in staging. There appears to be one active CSP issue, where [a font is loaded by a `data:` URI](https://sentry.prod.mozaws.net/share/issue/32d83e4b7d764479997dc4623b3df49e/), but I don't think we do this ourselves, this might be CSP doing its job.

I'm waiting to enable CSP reporting in production until the manually inlined JS examples experiment is done (https://github.com/mdn/sprints/issues/629).