### PR TITLE
PR for additional metrics

### DIFF
--- a/k8s/install/services/datadog/README.md
+++ b/k8s/install/services/datadog/README.md
@@ -1,2 +1,6 @@
 ## Datadog manifests
 This is for cluster wide stuff
+
+## Notes
+- `datadog-rbac.yaml` is there to allow kubernetes event collection
+- `datadog-agent.yaml` is a cluster wide manifest that get deployed to each node

--- a/k8s/install/services/datadog/datadog-agent.yaml
+++ b/k8s/install/services/datadog/datadog-agent.yaml
@@ -4,6 +4,8 @@ metadata:
   name: dd-agent
   namespace: datadog
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -11,6 +13,7 @@ spec:
       name: dd-agent
       namespace: datadog
     spec:
+      serviceAccountName: datadog-agent
       tolerations:
         - operator: "Exists"
           key: "node-role.kubernetes.io/master"
@@ -37,6 +40,8 @@ spec:
             value: "yes"
           - name: SD_BACKEND
             value: docker
+          - name: DD_COLLECT_KUBERNETES_EVENTS
+            value: "true"
         volumeMounts:
           - name: dockersocket
             mountPath: /var/run/docker.sock

--- a/k8s/install/services/datadog/datadog-agent.yaml
+++ b/k8s/install/services/datadog/datadog-agent.yaml
@@ -19,7 +19,7 @@ spec:
           key: "node-role.kubernetes.io/master"
           effect: "NoSchedule"
       containers:
-      - image: datadog/docker-dd-agent:latest
+      - image: datadog/agent:latest
         imagePullPolicy: Always
         resources:
           limits:
@@ -30,17 +30,22 @@ spec:
           - containerPort: 8125
             name: dogstatsdport
             protocol: UDP
+          - containerPort: 8126
+            name: traceport
+            protocol: TCP
         env:
-          - name: API_KEY
+          - name: DD_API_KEY
             valueFrom:
               secretKeyRef:
                 name: datadog-cluster-secrets
                 key: API_KEY
           - name: KUBERNETES
-            value: "yes"
+            value: "true"
           - name: SD_BACKEND
             value: docker
           - name: DD_COLLECT_KUBERNETES_EVENTS
+            value: "true"
+          - name: DD_LEADER_ELECTION
             value: "true"
         volumeMounts:
           - name: dockersocket
@@ -51,6 +56,12 @@ spec:
           - name: cgroups
             mountPath: /host/sys/fs/cgroup
             readOnly: true
+        livenessProbe:
+          exec:
+            command:
+            - ./probe.sh
+          initialDelaySeconds: 15
+          periodSeconds: 5
       volumes:
         - hostPath:
             path: /var/run/docker.sock

--- a/k8s/install/services/datadog/datadog-rbac.yaml
+++ b/k8s/install/services/datadog/datadog-rbac.yaml
@@ -1,0 +1,72 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: datadog-agent
+  namespace: datadog
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: datadog-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-agent
+subjects:
+- kind: ServiceAccount
+  name: datadog-agent
+  namespace: datadog
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: datadog-agent
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - events
+  - endpoints
+  - pods
+  - nodes
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["quota.openshift.io"]
+  resources:
+  - clusterresourcequotas
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - datadogtoken             # Kubernetes event collection state
+  - datadog-leader-election  # Leader election token
+  verbs:
+  - get
+  - update
+- apiGroups:  # To create the leader election token
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+- nonResourceURLs:
+  - "/version"
+  - "/healthz"
+  verbs:
+  - get
+- apiGroups:  # Kubelet connectivity
+  - ""
+  resources:
+  - nodes/metrics
+  - nodes/spec
+  - nodes/proxy
+  verbs:
+  - get

--- a/k8s/install/services/kube-state-metrics/kube-state-metrics-cluster-role-binding.yaml
+++ b/k8s/install/services/kube-state-metrics/kube-state-metrics-cluster-role-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1 
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: kube-system
+

--- a/k8s/install/services/kube-state-metrics/kube-state-metrics-cluster-role.yaml
+++ b/k8s/install/services/kube-state-metrics/kube-state-metrics-cluster-role.yaml
@@ -1,0 +1,44 @@
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kube-state-metrics
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - secrets
+  - nodes
+  - pods
+  - services
+  - resourcequotas
+  - replicationcontrollers
+  - limitranges
+  - persistentvolumeclaims
+  - persistentvolumes
+  - namespaces
+  - endpoints
+  verbs: ["list", "watch"]
+- apiGroups: ["extensions"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs: ["list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+  - statefulsets
+  verbs: ["list", "watch"]
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs: ["list", "watch"]
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+- apiGroups: ["policy"]
+  resources:
+  - poddisruptionbudgets
+  verbs: ["list", "watch"]

--- a/k8s/install/services/kube-state-metrics/kube-state-metrics-deployment.yaml
+++ b/k8s/install/services/kube-state-metrics/kube-state-metrics-deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1beta2
+# Kubernetes versions after 1.9.0 should use apps/v1
+# Kubernetes versions before 1.8.0 should use apps/v1beta1 or extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-state-metrics
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-state-metrics
+    spec:
+      serviceAccountName: kube-state-metrics
+      containers:
+      - name: kube-state-metrics
+        image: quay.io/coreos/kube-state-metrics:v1.4.0
+        ports:
+        - name: http-metrics
+          containerPort: 8080
+        - name: telemetry
+          containerPort: 8081
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+      - name: addon-resizer
+        image: k8s.gcr.io/addon-resizer:1.8.3
+        resources:
+          limits:
+            cpu: 150m
+            memory: 50Mi
+          requests:
+            cpu: 150m
+            memory: 50Mi
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        command:
+          - /pod_nanny
+          - --container=kube-state-metrics
+          - --cpu=100m
+          - --extra-cpu=1m
+          - --memory=100Mi
+          - --extra-memory=2Mi
+          - --threshold=5
+          - --deployment=kube-state-metrics

--- a/k8s/install/services/kube-state-metrics/kube-state-metrics-role-binding.yaml
+++ b/k8s/install/services/kube-state-metrics/kube-state-metrics-role-binding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: kube-state-metrics
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kube-state-metrics-resizer
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: kube-system
+

--- a/k8s/install/services/kube-state-metrics/kube-state-metrics-role.yaml
+++ b/k8s/install/services/kube-state-metrics/kube-state-metrics-role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  namespace: kube-system
+  name: kube-state-metrics-resizer
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["get"]
+- apiGroups: ["extensions"]
+  resources:
+  - deployments
+  resourceNames: ["kube-state-metrics"]
+  verbs: ["get", "update"]
+

--- a/k8s/install/services/kube-state-metrics/kube-state-metrics-service-account.yaml
+++ b/k8s/install/services/kube-state-metrics/kube-state-metrics-service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: kube-system
+

--- a/k8s/install/services/kube-state-metrics/kube-state-metrics-service.yaml
+++ b/k8s/install/services/kube-state-metrics/kube-state-metrics-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: kube-system
+  labels:
+    k8s-app: kube-state-metrics
+  annotations:
+    prometheus.io/scrape: 'true'
+spec:
+  ports:
+  - name: http-metrics
+    port: 8080
+    targetPort: http-metrics
+    protocol: TCP
+  - name: telemetry
+    port: 8081
+    targetPort: telemetry
+    protocol: TCP
+  selector:
+    k8s-app: kube-state-metrics
+


### PR DESCRIPTION
PR includes a couple of things

- Updates datadog agent to v6 (Fixes #156 )
- Installs kube-state-metrics to get kubernetes state
- Enable kubernetes event collections (Fixes #153 )