### PR TITLE
bug 1490727: Add a monthly payments ID for prod

### DIFF
--- a/apps/mdn/mdn-aws/k8s/regions/oregon/prod.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/prod.sh
@@ -128,6 +128,7 @@ export KUMA_SECURE_HSTS_SECONDS=63072000
 export KUMA_SERVE_LEGACY=True
 export KUMA_SESSION_COOKIE_SECURE=True
 export KUMA_STATIC_URL=https://developer.mozilla.org/static/
+export KUMA_STRIPE_PRODUCT_ID=prod_monthly
 export KUMA_STRIPE_PUBLIC_KEY=pk_live_GZl4tCi8J5mWhKbJeRey4DSy
 export KUMA_WEB_CONCURRENCY=4
 


### PR DESCRIPTION
Add ``KUMA_STRIPE_PRODUCT_ID`` so that production users can subscribe to support MDN each month.