### PR TITLE
Adding a lifecycle rule for mdn-elb-logs bucket

### DIFF
--- a/apps/mdn/mdn-aws/infra/modules/shared/mdn_shared_infra.tf
+++ b/apps/mdn/mdn-aws/infra/modules/shared/mdn_shared_infra.tf
@@ -21,9 +21,9 @@ resource "random_id" "rand-var" {
 }
 
 locals {
-  downloads             = "${var.downloads_bucket_name}"
-  elb_logs              = "${var.elb_logs_bucket_name}-${random_id.rand-var.hex}"
-  shared_backup         = "${var.shared_backup_bucket_name}-${random_id.rand-var.hex}"
+  downloads     = "${var.downloads_bucket_name}"
+  elb_logs      = "${var.elb_logs_bucket_name}-${random_id.rand-var.hex}"
+  shared_backup = "${var.shared_backup_bucket_name}-${random_id.rand-var.hex}"
 }
 
 resource "aws_s3_bucket" "mdn-elb-logs" {
@@ -32,6 +32,14 @@ resource "aws_s3_bucket" "mdn-elb-logs" {
   bucket = "${local.elb_logs}"
   region = "${var.region}"
   acl    = "log-delivery-write"
+
+  lifecycle_rule {
+    enabled = true
+
+    expiration {
+      days = 30
+    }
+  }
 
   policy = <<EOF
 {


### PR DESCRIPTION
Adds a lifecycle rule to the s3 bucket, this code already lives on the AWS account so just documenting in terraform to close the loop