### PR TITLE
bug 1404669: add redirect=no to KS doc URL template

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -129,7 +129,7 @@ export INTERACTIVE_EXAMPLES_BASE_URL ?= https://interactive-examples.mdn.mozilla
 
 # Derived environment variables for both Kuma and Kumascript. These are always set.
 export KUMA_URL_TEMPLATE_FOR_KUMASCRIPT=http://${KUMASCRIPT_SERVICE_NAME}:${KUMASCRIPT_SERVICE_PORT}/docs/{path}
-export KUMASCRIPT_DOCUMENT_URL_TEMPLATE=http://${API_SERVICE_NAME}/en-US/docs/{path}?raw=1
+export KUMASCRIPT_DOCUMENT_URL_TEMPLATE=http://${API_SERVICE_NAME}/en-US/docs/{path}?raw=1&redirect=no
 export KUMASCRIPT_LIVE_SAMPLES_BASE_URL=${KUMA_PROTOCOL}${KUMA_ATTACHMENT_HOST}
 
 # MDN backup tool


### PR DESCRIPTION
This PR fixes the handling of the document-based redirects when `?redirect=no` is used ([bug 1404669](https://bugzilla.mozilla.org/show_bug.cgi?id=1404669)). The body of the resulting document page should simply show the redirect directive along with its associated link to the target page (`REDIRECT ...`), but the content of the target page is shown instead. The problem arises when the HTML of the redirect document is rendered. Kuma makes a render request (via `GET`) to Kumascript, which in turn must request the document from Kuma, but since the document contains a redirect directive and the document has been requested by Kumascript without suppressing the redirection with `redirect=no`, the content of the target page is eventually returned to Kumascript, which it dutifully renders, returns to Kuma, and that's what gets displayed.

This PR takes the approach of suppressing the redirection (by adding `redirect=no`) on the document request that Kumascript makes to Kuma during the rendering process. That solution is simple, but requires all of the documents that are content-based redirects to be re-rendered (to shed their cached content -- which is the content of their target page). Another approach, which avoids the need for re-rendering, is to simply bypass the rendering for content-based redirects. From my exploration of that approach, it wasn't nearly as simple, since it ran against the grain of the current code, and seemed riskier in terms of potentially introducing new problems.

This PR requires that all content-based redirection documents eventually be re-rendered after it's deployed. On the stage instance, that is 62335 documents, and on the production instance 65989 documents.