### PR TITLE
Split percona toolkit secret and command

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -224,7 +224,7 @@ export DATADOG_REDIS_CONFIG ?= foo
 export DATADOG_REDIS_CONFIG_BASE64 ?= $(shell echo -n "${DATADOG_REDIS_CONFIG}" | base64)
 
 export PERCONA_TOOLKIT_NS ?= percona-toolkit
-export PERCONA_TOOLKIT_IMAGE ?= mdnwebdocs/percona-toolkit:28c04d8
+export PERCONA_TOOLKIT_IMAGE ?= mdnwebdocs/percona-toolkit:300705b
 
 ###############################
 ### core tasks

--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -224,7 +224,7 @@ export DATADOG_REDIS_CONFIG ?= foo
 export DATADOG_REDIS_CONFIG_BASE64 ?= $(shell echo -n "${DATADOG_REDIS_CONFIG}" | base64)
 
 export PERCONA_TOOLKIT_NS ?= percona-toolkit
-export PERCONA_TOOLKIT_IMAGE ?= quay.io/metadave/percona-toolkit:3b90d7e
+export PERCONA_TOOLKIT_IMAGE ?= mdnwebdocs/percona-toolkit:28c04d8
 
 ###############################
 ### core tasks

--- a/apps/mdn/mdn-aws/k8s/percona-toolkit-ptkill.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/percona-toolkit-ptkill.yaml.j2
@@ -19,11 +19,6 @@ spec:
       - name: percona-toolkit-ptkill
         image: {{ PERCONA_TOOLKIT_IMAGE }}
         env:
-          - name: PT_CMD
-            valueFrom:
-              secretKeyRef:
-                name: percona-toolkit-ptkill-secrets
-                key: pt_cmd
           - name: PTDEBUG
             value: "0"
           - name: DB_HOST

--- a/apps/mdn/mdn-aws/k8s/percona-toolkit-ptkill.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/percona-toolkit-ptkill.yaml.j2
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: percona-toolkit-ptkill
-  namespace: {{ env['PERCONA_TOOLKIT_NS'] }}
+  namespace: {{ PERCONA_TOOLKIT_NS }}
   labels:
     app: percona-toolkit-ptkill
 spec:
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: percona-toolkit-ptkill
-        image: {{ env['PERCONA_TOOLKIT_IMAGE'] }}
+        image: {{ PERCONA_TOOLKIT_IMAGE }}
         env:
           - name: PT_CMD
             valueFrom:
@@ -26,6 +26,26 @@ spec:
                 key: pt_cmd
           - name: PTDEBUG
             value: "0"
+          - name: DB_HOST
+            valueFrom:
+              secretKeyRef:
+                name: percona-toolkit-ptkill-secrets
+                key: db_host
+          - name: DB_NAME
+            valueFrom:
+              secretKeyRef:
+                name: percona-toolkit-ptkill-secrets
+                key: db_name
+          - name: DB_USER
+            valueFrom:
+              secretKeyRef:
+                name: percona-toolkit-ptkill-secrets
+                key: db_user
+          - name: DB_PASS
+            valueFrom:
+              secretKeyRef:
+                name: percona-toolkit-ptkill-secrets
+                key: db_pass
         resources:
           requests:
             memory: "64Mi"

--- a/apps/mdn/utils/percona_toolkit/Makefile
+++ b/apps/mdn/utils/percona_toolkit/Makefile
@@ -1,7 +1,0 @@
-VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD)
-IMAGE_PREFIX ?= quay.io/metadave
-IMAGE_NAME ?= percona-toolkit
-
-all:
-	docker build . -t ${IMAGE_PREFIX}/${IMAGE_NAME}:${VERSION}
-	docker push ${IMAGE_PREFIX}/${IMAGE_NAME}:${VERSION}

--- a/apps/mdn/utils/percona_toolkit/build.sh
+++ b/apps/mdn/utils/percona_toolkit/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+GIT_COMMIT=$(git rev-parse --short=7 HEAD)
+
+docker build -t mdnwebdocs/percona-toolkit:${GIT_COMMIT} .
+docker push mdnwebdocs/percona-toolkit:${GIT_COMMIT}

--- a/apps/mdn/utils/percona_toolkit/run.sh
+++ b/apps/mdn/utils/percona_toolkit/run.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
-${PT_CMD}
+PT_KILL_OPTIONS="--busy-time=30m --kill --print --victims=all --verbose"
+PT_KILL_CREDS="h=${DB_HOST},D=${DB_NAME},u=${DB_USER},p=${DB_PASS}"
 
+pt-kill ${PT_KILL_OPTIONS} ${PT_KILL_CREDS}


### PR DESCRIPTION
This splits the command and secret up so we will no longer need to update the secret to get a new command. This fixes part of #169 