### PR TITLE
bug 1509430: Quote integers as environment strings

### DIFF
--- a/apps/mdn/mdn-aws/k8s/kumascript.deploy.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kumascript.deploy.yaml.j2
@@ -27,11 +27,11 @@ spec:
             - name: INTERACTIVE_EXAMPLES_URL
               value: {{ INTERACTIVE_EXAMPLES_BASE_URL }}
             - name: KUMASCRIPT_PORT
-              value: {{ KUMASCRIPT_CONTAINER_PORT }}
+              value: "{{ KUMASCRIPT_CONTAINER_PORT }}"
             - name: KUMASCRIPT_CACHE_MEGABYTES
-              value: {{ KUMASCRIPT_CACHE_MEGABYTES }}
+              value: "{{ KUMASCRIPT_CACHE_MEGABYTES }}"
             - name: KUMASCRIPT_CACHE_MINUTES
-              value: {{ KUMASCRIPT_CACHE_MINUTES }}
+              value: "{{ KUMASCRIPT_CACHE_MINUTES }}"
             - name: LIVE_SAMPLES_URL
               value: {{ KUMASCRIPT_LIVE_SAMPLES_BASE_URL }}
             - name: NEW_RELIC_APP_NAME


### PR DESCRIPTION
When applying PR #175, we get this error:

```
"STDIN": cannot convert int64 to string
```

It appears that values sent in the environment must be strings.