### PR TITLE
Cluster tweaks

### DIFF
--- a/k8s/clusters/eu-central-1a/out/terraform/cluster_autoscaler.tf
+++ b/k8s/clusters/eu-central-1a/out/terraform/cluster_autoscaler.tf
@@ -1,0 +1,29 @@
+resource "aws_iam_policy" "nodes-k8s-eu-central-1a-mdn-mozit-cloud-autoscaler-policy" {
+  name        = "nodes-k8s-eu-central-1a-mdn-mozit-cloud-autoscaler-policy"
+  path        = "/"
+  description = "Policy for K8s AWS autoscaler"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeAutoScalingInstances",
+								"autoscaling:DescribeTags",
+                "autoscaling:SetDesiredCapacity",
+                "autoscaling:TerminateInstanceInAutoScalingGroup"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "autoscaler-attach" {
+  role       = "${aws_iam_role.nodes-k8s-eu-central-1a-mdn-mozit-cloud.name}"
+  policy_arn = "${aws_iam_policy.nodes-k8s-eu-central-1a-mdn-mozit-cloud-autoscaler-policy.arn}"
+}

--- a/k8s/clusters/eu-central-1a/out/terraform/cluster_autoscaler.tf
+++ b/k8s/clusters/eu-central-1a/out/terraform/cluster_autoscaler.tf
@@ -12,7 +12,7 @@ resource "aws_iam_policy" "nodes-k8s-eu-central-1a-mdn-mozit-cloud-autoscaler-po
             "Action": [
                 "autoscaling:DescribeAutoScalingGroups",
                 "autoscaling:DescribeAutoScalingInstances",
-								"autoscaling:DescribeTags",
+                "autoscaling:DescribeTags",
                 "autoscaling:SetDesiredCapacity",
                 "autoscaling:TerminateInstanceInAutoScalingGroup"
             ],

--- a/k8s/clusters/eu-central-1a/out/terraform/kubernetes.tf
+++ b/k8s/clusters/eu-central-1a/out/terraform/kubernetes.tf
@@ -346,14 +346,14 @@ resource "aws_security_group_rule" "all-node-to-node" {
   protocol                 = "-1"
 }
 
-resource "aws_security_group_rule" "https-external-to-master-0-0-0-0--0" {
-  type              = "ingress"
-  security_group_id = "${aws_security_group.masters-k8s-eu-central-1a-mdn-mozit-cloud.id}"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-}
+#resource "aws_security_group_rule" "https-external-to-master-0-0-0-0--0" {
+#  type              = "ingress"
+#  security_group_id = "${aws_security_group.masters-k8s-eu-central-1a-mdn-mozit-cloud.id}"
+#  from_port         = 443
+#  to_port           = 443
+#  protocol          = "tcp"
+#  cidr_blocks       = ["0.0.0.0/0"]
+#}
 
 resource "aws_security_group_rule" "master-egress" {
   type              = "egress"
@@ -418,23 +418,23 @@ resource "aws_security_group_rule" "node-to-master-udp-1-65535" {
   protocol                 = "udp"
 }
 
-resource "aws_security_group_rule" "ssh-external-to-master-0-0-0-0--0" {
-  type              = "ingress"
-  security_group_id = "${aws_security_group.masters-k8s-eu-central-1a-mdn-mozit-cloud.id}"
-  from_port         = 22
-  to_port           = 22
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-}
+#resource "aws_security_group_rule" "ssh-external-to-master-0-0-0-0--0" {
+#  type              = "ingress"
+#  security_group_id = "${aws_security_group.masters-k8s-eu-central-1a-mdn-mozit-cloud.id}"
+#  from_port         = 22
+#  to_port           = 22
+#  protocol          = "tcp"
+#  cidr_blocks       = ["0.0.0.0/0"]
+#}
 
-resource "aws_security_group_rule" "ssh-external-to-node-0-0-0-0--0" {
-  type              = "ingress"
-  security_group_id = "${aws_security_group.nodes-k8s-eu-central-1a-mdn-mozit-cloud.id}"
-  from_port         = 22
-  to_port           = 22
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-}
+#resource "aws_security_group_rule" "ssh-external-to-node-0-0-0-0--0" {
+#  type              = "ingress"
+#  security_group_id = "${aws_security_group.nodes-k8s-eu-central-1a-mdn-mozit-cloud.id}"
+#  from_port         = 22
+#  to_port           = 22
+#  protocol          = "tcp"
+#  cidr_blocks       = ["0.0.0.0/0"]
+#}
 
 resource "aws_subnet" "eu-central-1a-k8s-eu-central-1a-mdn-mozit-cloud" {
   vpc_id            = "${aws_vpc.k8s-eu-central-1a-mdn-mozit-cloud.id}"

--- a/k8s/clusters/us-west-2a/out/terraform/cluster_autoscaler.tf
+++ b/k8s/clusters/us-west-2a/out/terraform/cluster_autoscaler.tf
@@ -13,6 +13,7 @@ resource "aws_iam_policy" "nodes-k8s-us-west-2a-mdn-mozit-cloud-autoscaler-polic
             "Action": [
                 "autoscaling:DescribeAutoScalingGroups",
                 "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeTags",
                 "autoscaling:SetDesiredCapacity",
                 "autoscaling:TerminateInstanceInAutoScalingGroup"
             ],

--- a/k8s/clusters/us-west-2a/out/terraform/kubernetes.tf
+++ b/k8s/clusters/us-west-2a/out/terraform/kubernetes.tf
@@ -308,14 +308,14 @@ resource "aws_security_group_rule" "all-node-to-node" {
   protocol                 = "-1"
 }
 
-resource "aws_security_group_rule" "https-external-to-master-0-0-0-0--0" {
-  type              = "ingress"
-  security_group_id = "${aws_security_group.masters-k8s-us-west-2a-mdn-mozit-cloud.id}"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-}
+#resource "aws_security_group_rule" "https-external-to-master-0-0-0-0--0" {
+#  type              = "ingress"
+#  security_group_id = "${aws_security_group.masters-k8s-us-west-2a-mdn-mozit-cloud.id}"
+#  from_port         = 443
+#  to_port           = 443
+#  protocol          = "tcp"
+#  cidr_blocks       = ["0.0.0.0/0"]
+#}
 
 resource "aws_security_group_rule" "master-egress" {
   type              = "egress"
@@ -380,23 +380,23 @@ resource "aws_security_group_rule" "node-to-master-udp-1-65535" {
   protocol                 = "udp"
 }
 
-resource "aws_security_group_rule" "ssh-external-to-master-0-0-0-0--0" {
-  type              = "ingress"
-  security_group_id = "${aws_security_group.masters-k8s-us-west-2a-mdn-mozit-cloud.id}"
-  from_port         = 22
-  to_port           = 22
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-}
+#resource "aws_security_group_rule" "ssh-external-to-master-0-0-0-0--0" {
+#  type              = "ingress"
+#  security_group_id = "${aws_security_group.masters-k8s-us-west-2a-mdn-mozit-cloud.id}"
+#  from_port         = 22
+#  to_port           = 22
+#  protocol          = "tcp"
+#  cidr_blocks       = ["0.0.0.0/0"]
+#}
 
-resource "aws_security_group_rule" "ssh-external-to-node-0-0-0-0--0" {
-  type              = "ingress"
-  security_group_id = "${aws_security_group.nodes-k8s-us-west-2a-mdn-mozit-cloud.id}"
-  from_port         = 22
-  to_port           = 22
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-}
+#resource "aws_security_group_rule" "ssh-external-to-node-0-0-0-0--0" {
+#  type              = "ingress"
+#  security_group_id = "${aws_security_group.nodes-k8s-us-west-2a-mdn-mozit-cloud.id}"
+#  from_port         = 22
+#  to_port           = 22
+#  protocol          = "tcp"
+#  cidr_blocks       = ["0.0.0.0/0"]
+#}
 
 resource "aws_subnet" "us-west-2a-k8s-us-west-2a-mdn-mozit-cloud" {
   vpc_id            = "${aws_vpc.k8s-us-west-2a-mdn-mozit-cloud.id}"


### PR DESCRIPTION
This fixes several minor issues listed below:

 - Add "autoscaling:DescribeTags" permissions to cluster autoscaler IAM
 role
 - Add cluster autoscaler IAM permission for the Frankfurt cluster
 - Comment out external ssh and https security group rule and only allow
 specific IP to ssh and talk to the kubernetes cluster