### PR TITLE
update k8s folder deployments to use apps/v1 apiVersion

### DIFF
--- a/apps/mdn/mdn-aws/k8s/kuma.base.deploy.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kuma.base.deploy.yaml.j2
@@ -1,9 +1,12 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ KUMA_NAME }}
 spec:
   replicas: {{ KUMA_REPLICAS }}
+  selector:
+    matchLabels:
+      app: {{ KUMA_APP_LABEL }}
   template:
     metadata:
       labels:

--- a/apps/mdn/mdn-aws/k8s/kumascript.deploy.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kumascript.deploy.yaml.j2
@@ -1,9 +1,12 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ KUMASCRIPT_NAME }}
 spec:
   replicas: {{ KUMASCRIPT_REPLICAS }}
+  selector:
+    matchLabels:
+      app: {{ KUMASCRIPT_APP_LABEL }}
   template:
     metadata:
       labels:

--- a/apps/mdn/mdn-aws/k8s/mdn-admin-node.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/mdn-admin-node.yaml.j2
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ ADMIN_NODE_NAME }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ ADMIN_NODE_NAME }}
   template:
     metadata:
       labels:

--- a/apps/mdn/mdn-aws/k8s/mdn-dd-redis.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/mdn-dd-redis.yaml.j2
@@ -1,8 +1,11 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ DATADOG_REDIS_DEPLOYMENT_NAME }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ DATADOG_REDIS_DEPLOYMENT_NAME }}
   template:
     metadata:
       labels:
@@ -75,4 +78,3 @@ spec:
               items:
                 - key: REDIS_CONFIG_FILE
                   path: redisdb.yaml
-


### PR DESCRIPTION
Here are the K8s resource API's that we're currently using:
- `Service`: `v1`
- `Deployment`: `extensions/v1beta1` (except the percona pt-kill deployment, which is up-to-date at `apps/v1`)
- `CronJob`: `batch/v1beta1`
- `Job`: `batch/v1`
- `Secret`: `v1`
- `PersistentVolume`: `v1`
- `PersistentVolumeClaim`: `v1`

When I checked these against the [latest versions recommended for K8s 1.11](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#-strong-api-overview-strong-) (we're at 1.11.7 since the upgrade), they all looked good except for our deployments, which need to move to version `apps/v1`, which this PR does.

This has not yet been tested, so I'll test on stage early next week and post the results below.

There are additional deployments outside the `apps/mdn/mdn-aws/k8s` folder that perhaps need to be updated as well, but I'll let @limed make the call on those.