### PR TITLE
Expand CSP for mdn.dev

### DIFF
--- a/apps/mdn/mdn-dev/modules/cdn/lambda-headers.js
+++ b/apps/mdn/mdn-dev/modules/cdn/lambda-headers.js
@@ -30,9 +30,21 @@ exports.handler = (event, context, callback) => {
 
     headers['content-security-policy'] = [{
         key:   'Content-Security-Policy',
-        value: "default-src 'none'; img-src 'self'; script-src 'unsafe-inline'; style-src 'self'"
+        value: ("default-src 'none'" +
+                "; img-src 'self'" +
+                "; script-src 'self'" +
+                "; style-src" +
+                  " 'self'" +
+                  // Hash of empty string, injected by webpack
+                  " 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='" +
+                "; font-src 'self'" +
+                // Observatory recommendations
+                "; frame-ancestors 'none'" +
+                "; base-uri 'none'" +
+                "; form-action 'none'")
     }];
 
     callback(null, response);
 
 };
+


### PR DESCRIPTION
Update CSP for the initial version at https://github.com/mdn/mdn.dev/tree/master/static, and reformat code with comments and shorter lines.

This was manually applied in the AWS console, and is the current code applied for CloudFront on https://mdn.dev. [Observatory is happy](https://observatory.mozilla.org/analyze/mdn.dev).