### PR TITLE
add pass-through behavior for the api endpoints

### DIFF
--- a/apps/mdn/mdn-aws/infra/modules/mdn-cdn/cloudfront_primary/README.md
+++ b/apps/mdn/mdn-aws/infra/modules/mdn-cdn/cloudfront_primary/README.md
@@ -11,6 +11,7 @@ compression, but GZip only (Brotli compression is not yet supported).
 CloudFront will
 [cache many error responses by default](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/HTTPStatusCodes.html#HTTPStatusCodes-cached-errors),
 so we include custom error responses that effectively turn-off the caching for:
+* `400 Bad Request`
 * `403 Forbidden`
 * `404 Not Found`
 * `500 Internal Server Error`
@@ -22,29 +23,29 @@ explicitly configured via the header, cookie, and query-parameter configuration
 within each behavior.
 
 ## Static and Media Behaviors
-The first two behaviors (`#0` and `#1`) match against requests for static and media
-files. The responses to these requests are cached for long periods of time
-(typically a year or more). These two behaviors eliminate the need for a
+The first three behaviors (`#0`, `#1`, and `#2`) match against requests for static
+and media files. The responses to these requests are cached for long periods of time
+(typically a year or more). These behaviors eliminate the need for a
 separate CDN for the static/media assets.
 
 ## Pass-Through Behaviors
-Each of these behaviors, `#2` through `#13` as well as `#18` through `#24`, share the
-same configuration except for the path pattern, and are designed to simply
+Each of these behaviors, `#3` through `#14` as well as `#19` through `#26`, share
+the same configuration except for the path pattern, and are designed to simply
 forward the complete incoming request to the origin (all headers, cookies,
 and query parameters), and perform **no** caching of the response. Most,
 if not all, of these behaviors match endpoints that allow `POST` requests that
 depend upon a `csrftoken` cookie, which is so varied as to make caching
-useless anyway. Also, all of these behaviors match endpoints that require
+useless anyway. Also, most of these behaviors match endpoints that require
 login, so not caching them is of almost no consequence since requests
 from logged-in users comprise only a tiny fraction of the total requests.
 
 ## Dashboard Caching Behaviors
-Behaviors `#15`, `#16`, and `#17`, are designed specifically for the three
+Behaviors `#16`, `#17`, and `#18`, are designed specifically for the three
 dashboard endpoints that can vary caching based on the `X-Requested-With`
 header.
 
 ## Core Document Behavior
-Behavior `#14` handles the core requests to MDN, the document requests.
+Behavior `#15` handles the core requests to MDN, the document requests.
 
 ## Default Behavior
 The default behavior handles all requests that do not match any of the

--- a/apps/mdn/mdn-aws/infra/modules/mdn-cdn/cloudfront_primary/cloudfront.tf
+++ b/apps/mdn/mdn-aws/infra/modules/mdn-cdn/cloudfront_primary/cloudfront.tf
@@ -719,6 +719,30 @@ resource "aws_cloudfront_distribution" "mdn-primary-cf-dist" {
     }
   }
 
+  # 26
+  ordered_cache_behavior {
+    path_pattern = "api/*"
+
+    allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    min_ttl                = 0
+    smooth_streaming       = false
+    target_origin_id       = "${var.distribution_name}"
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = true
+      headers      = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
   default_cache_behavior {
     allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
     cached_methods         = ["GET", "HEAD"]


### PR DESCRIPTION
This PR adds a pass-through behavior to the Terraform on the stage and prod CDN's for the future `/api/*` family of endpoints and is a companion to https://github.com/mozilla/kuma/pull/5285. I've already made this change on the stage CDN as an experiment, but I can remove/update that if needed. I've also updated `apps/mdn/mdn-aws/infra/modules/mdn-cdn/cloudfront_primary/README.md` to reflect the latest behaviors.