### PR TITLE
change CDN behavior from contribute to payments

### DIFF
--- a/apps/mdn/mdn-aws/infra/modules/mdn-cdn/cloudfront_primary/cloudfront.tf
+++ b/apps/mdn/mdn-aws/infra/modules/mdn-cdn/cloudfront_primary/cloudfront.tf
@@ -673,7 +673,7 @@ resource "aws_cloudfront_distribution" "mdn-primary-cf-dist" {
 
   # 24
   ordered_cache_behavior {
-    path_pattern = "*/contribute"
+    path_pattern = "*/payments/*"
 
     allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
     cached_methods         = ["GET", "HEAD"]


### PR DESCRIPTION
This PR corrects something we should have changed a few months ago when merging https://github.com/mozilla/kuma/pull/5039 (oops!). This has already been changed on the stage and production CloudFront CDN's (thanks to @jwhitlock for doing that and discovering this issue!).