### PR TITLE
update allowed hosts

### DIFF
--- a/apps/mdn/mdn-aws/k8s/regions/germany/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/germany/prod.mm.sh
@@ -51,7 +51,7 @@ export WEB_CPU_LIMIT=4
 export WEB_CPU_REQUEST=500m
 export WEB_MEMORY_LIMIT=6Gi
 export WEB_MEMORY_REQUEST=4Gi
-export WEB_ALLOWED_HOSTS="developer.mozilla.org,cdn.mdn.mozilla.net,mdn.mozillademos.org,demos.mdn.mozit.cloud,demos-origin.mdn.mozit.cloud,developer-prod.mdn.mozit.cloud,prod.mdn.mozit.cloud,standby.mdn.mozit.cloud,developer.mozilla.com,mdn.mozilla.org,developer-new.mozilla.org,developers.mozilla.org"
+export WEB_ALLOWED_HOSTS="developer.mozilla.org,beta.developer.mozilla.org,wiki.developer.mozilla.org,cdn.mdn.mozilla.net,mdn.mozillademos.org,demos.mdn.mozit.cloud,demos-origin.mdn.mozit.cloud,developer-prod.mdn.mozit.cloud,prod.mdn.mozit.cloud,standby.mdn.mozit.cloud"
 
 export API_NAME=api
 export API_REPLICAS=1

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.sh
@@ -51,7 +51,7 @@ export WEB_CPU_LIMIT=4
 export WEB_CPU_REQUEST=500m
 export WEB_MEMORY_LIMIT=6Gi
 export WEB_MEMORY_REQUEST=4Gi
-export WEB_ALLOWED_HOSTS="developer.mozilla.org,cdn.mdn.mozilla.net,mdn.mozillademos.org,demos.mdn.mozit.cloud,demos-origin.mdn.mozit.cloud,developer-prod.mdn.mozit.cloud,prod.mdn.mozit.cloud,developer.mozilla.com,mdn.mozilla.org,developer-new.mozilla.org,developers.mozilla.org"
+export WEB_ALLOWED_HOSTS="developer.mozilla.org,beta.developer.mozilla.org,wiki.developer.mozilla.org,cdn.mdn.mozilla.net,mdn.mozillademos.org,demos.mdn.mozit.cloud,demos-origin.mdn.mozit.cloud,developer-prod.mdn.mozit.cloud,prod.mdn.mozit.cloud"
 
 export API_NAME=api
 export API_REPLICAS=2

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/prod.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/prod.sh
@@ -51,7 +51,7 @@ export WEB_CPU_LIMIT=4
 export WEB_CPU_REQUEST=500m
 export WEB_MEMORY_LIMIT=6Gi
 export WEB_MEMORY_REQUEST=4Gi
-export WEB_ALLOWED_HOSTS="developer.mozilla.org,cdn.mdn.mozilla.net,mdn.mozillademos.org,demos.mdn.mozit.cloud,demos-origin.mdn.mozit.cloud,developer-prod.mdn.mozit.cloud,prod.mdn.mozit.cloud,developer.mozilla.com,mdn.mozilla.org,developer-new.mozilla.org,developers.mozilla.org"
+export WEB_ALLOWED_HOSTS="developer.mozilla.org,beta.developer.mozilla.org,wiki.developer.mozilla.org,cdn.mdn.mozilla.net,mdn.mozillademos.org,demos.mdn.mozit.cloud,demos-origin.mdn.mozit.cloud,developer-prod.mdn.mozit.cloud,prod.mdn.mozit.cloud"
 
 export API_NAME=api
 export API_REPLICAS=2

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/stage.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/stage.mm.sh
@@ -51,7 +51,7 @@ export WEB_CPU_LIMIT=2
 export WEB_CPU_REQUEST=100m
 export WEB_MEMORY_LIMIT=6Gi
 export WEB_MEMORY_REQUEST=4Gi
-export WEB_ALLOWED_HOSTS="developer.allizom.org,developer-stage.mdn.mozit.cloud,stage.mdn.mozit.cloud,files-stage.mdn.mozit.cloud"
+export WEB_ALLOWED_HOSTS="developer.allizom.org,beta.developer.allizom.org,wiki.developer.allizom.org,developer-stage.mdn.mozit.cloud,stage.mdn.mozit.cloud,files-stage.mdn.mozit.cloud"
 
 export API_NAME=api
 export API_REPLICAS=1

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
@@ -51,7 +51,7 @@ export WEB_CPU_LIMIT=2
 export WEB_CPU_REQUEST=100m
 export WEB_MEMORY_LIMIT=6Gi
 export WEB_MEMORY_REQUEST=4Gi
-export WEB_ALLOWED_HOSTS="developer.allizom.org,developer-stage.mdn.mozit.cloud,stage.mdn.mozit.cloud,files-stage.mdn.mozit.cloud"
+export WEB_ALLOWED_HOSTS="developer.allizom.org,beta.developer.allizom.org,wiki.developer.allizom.org,developer-stage.mdn.mozit.cloud,stage.mdn.mozit.cloud,files-stage.mdn.mozit.cloud"
 
 export API_NAME=api
 export API_REPLICAS=1


### PR DESCRIPTION
This PR updates the `WEB_ALLOWED_HOSTS` setting for both stage and prod.

#### Stage
- add `beta.developer.allizom.org` and `wiki.developer.allizom.org`

#### Prod
- add `beta.developer.mozilla.org` and `wiki.developer.mozilla.org`
- remove legacy domains (per [bugzilla 1503261](https://bugzilla.mozilla.org/show_bug.cgi?id=1503261))
    - `developer.mozilla.com`
    - `mdn.mozilla.org`
    - `developer-new.mozilla.org`
    - `developers.mozilla.org`