### PR TITLE
Refactoring VPC code

### DIFF
--- a/vpc/eu-central-1/outputs.tf
+++ b/vpc/eu-central-1/outputs.tf
@@ -1,9 +1,9 @@
 output "vpc_id" {
-  value = "${local.vpc_id}"
+  value = "${module.vpc-eu-central-1.vpc_id}"
 }
 
 output "public_subnets" {
-  value = ["${data.aws_subnet_ids.public_subnets.ids}"]
+  value = "${module.subnets-eu-central-1.public_subnets}"
 }
 
 output "private_subnets" {

--- a/vpc/modules/subnets/main.tf
+++ b/vpc/modules/subnets/main.tf
@@ -1,85 +1,100 @@
 locals {
-  create_vpc = "${var.create_vpc ? 1 : 0}"
+  default_tags = {
+    Region    = "${var.region}"
+    Terraform = "true"
+  }
+
+  public_subnet_tags = {
+    SubnetType                = "Public"
+    "kubernetes.io/kops/role" = "public"
+    "kubernetes.io/role/elb"  = "1"
+  }
+
+  private_subnet_tags = {
+    SubnetType                        = "Private"
+    "kubernetes.io/kops/role"         = "private"
+    "kubernetes.io/role/internal-elb" = "1"
+  }
 }
 
-data "aws_availability_zone" "az" {
-  count = "${length(var.azs)}"
-  name  = "${var.azs[count.index]}"
+### Public Subnets ####
+resource "aws_subnet" "public" {
+  count = "${length(var.public_subnet_cidrs)}"
+
+  vpc_id                  = "${var.vpc_id}"
+  cidr_block              = "${var.public_subnet_cidrs[count.index]}"
+  availability_zone       = "${var.azs[count.index]}"
+  map_public_ip_on_launch = false
+
+  tags = "${merge(map("Name", "${var.vpc_name}-public-${var.azs[count.index]}"), local.default_tags, local.public_subnet_tags, var.tags)}"
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = "${var.vpc_id}"
+  tags   = "${merge(map("Name", "${var.vpc_name}-rt-public"), local.default_tags, local.public_subnet_tags, var.tags)}"
+}
+
+resource "aws_route" "public" {
+  route_table_id         = "${aws_route_table.public.id}"
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = "${var.igw_id}"
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = ["route_table_id", "nat_gateway_id"]
+  }
+
+  depends_on = ["aws_route_table.public"]
+}
+
+resource "aws_route_table_association" "public" {
+  count          = "${length(var.public_subnet_cidrs)}"
+  subnet_id      = "${element(aws_subnet.public.*.id, count.index)}"
+  route_table_id = "${aws_route_table.public.id}"
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = ["subnet_id"]
+  }
 }
 
 ### Private subnets ###
 resource "aws_subnet" "private" {
-  count = "${local.create_vpc * length(var.private_subnets_cidr)}"
+  count = "${length(var.private_subnet_cidrs)}"
 
   vpc_id                  = "${var.vpc_id}"
-  cidr_block              = "${var.private_subnets_cidr[count.index]}"
+  cidr_block              = "${var.private_subnet_cidrs[count.index]}"
+  availability_zone       = "${var.azs[count.index]}"
   map_public_ip_on_launch = false
 
-  tags {
-    Name                     = "${var.vpc_name}-private-${var.azs[count.index]}"
-    Region                   = "${var.region}"
-    SubnetType               = "Private"
-    "kubernetes.io/role/elb" = "1"
-    Terraform                = "true"
-  }
+  tags = "${merge(map("Name", "${var.vpc_name}-private-${var.azs[count.index]}"), local.default_tags, local.private_subnet_tags, var.tags)}"
 }
 
 # You get one thats it
 resource "aws_eip" "nat" {
-  count = "${local.create_vpc}"
-  vpc   = true
-
-  tags {
-    Name      = "${var.vpc_name}-nat"
-    Region    = "${var.region}"
-    Terraform = "true"
-  }
+  vpc  = true
+  tags = "${merge(map("Name", "${var.vpc_name}-nat"), local.default_tags)}"
 }
 
 # Just dump it into the first subnet
 resource "aws_nat_gateway" "nat_gw" {
-  count         = "${local.create_vpc}"      # we just want one nat gw
   allocation_id = "${aws_eip.nat.id}"
-  subnet_id     = "${var.public_subnets[0]}"
+  subnet_id     = "${element(aws_subnet.public.*.id, 0)}"
 
   lifecycle {
     create_before_destroy = true
     ignore_changes        = ["subnet_id"]
   }
 
-  tags {
-    Name      = "${var.vpc_name}-nat"
-    Region    = "${var.region}"
-    Terraform = "true"
-  }
+  tags = "${merge(map("Name", "${var.vpc_name}-nat"), local.default_tags)}"
 }
 
 resource "aws_route_table" "private" {
-  count  = "${local.create_vpc}"
   vpc_id = "${var.vpc_id}"
-
-  tags {
-    Name                      = "${var.vpc_name}-rt-private"
-    Region                    = "${var.region}"
-    Terraform                 = "true"
-    "kubernetes.io/kops/role" = "private"
-  }
-}
-
-resource "aws_route_table_association" "private" {
-  count = "${local.create_vpc * length(var.azs)}"
-
-  subnet_id      = "${element(aws_subnet.private.*.id, count.index)}"
-  route_table_id = "${element(aws_route_table.private.*.id, 0)}"
-
-  lifecycle {
-    create_before_destroy = true
-    ignore_changes        = ["subnet_id"]
-  }
+  tags   = "${merge(map("Name", "${var.vpc_name}-rt-private"), local.default_tags, local.private_subnet_tags, var.tags)}"
 }
 
 resource "aws_route" "private" {
-  count                  = "${local.create_vpc}"
   route_table_id         = "${aws_route_table.private.id}"
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = "${aws_nat_gateway.nat_gw.id}"
@@ -90,4 +105,15 @@ resource "aws_route" "private" {
   }
 
   depends_on = ["aws_nat_gateway.nat_gw"]
+}
+
+resource "aws_route_table_association" "private" {
+  count          = "${length(var.private_subnet_cidrs)}"
+  subnet_id      = "${element(aws_subnet.private.*.id, count.index)}"
+  route_table_id = "${element(aws_route_table.private.*.id, 0)}"
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = ["subnet_id"]
+  }
 }

--- a/vpc/modules/subnets/outputs.tf
+++ b/vpc/modules/subnets/outputs.tf
@@ -2,6 +2,10 @@ output "private_subnets" {
   value = ["${aws_subnet.private.*.id}"]
 }
 
+output "public_subnets" {
+  value = ["${aws_subnet.public.*.id}"]
+}
+
 output "nat_gateway_ids" {
   value = ["${aws_nat_gateway.nat_gw.*.id}"]
 }

--- a/vpc/modules/subnets/variables.tf
+++ b/vpc/modules/subnets/variables.tf
@@ -23,6 +23,5 @@ variable "public_subnet_cidrs" {
 }
 
 variable "private_subnet_cidrs" {
-  type    = "list"
-  default = []
+  type = "list"
 }

--- a/vpc/modules/subnets/variables.tf
+++ b/vpc/modules/subnets/variables.tf
@@ -2,27 +2,27 @@ variable "region" {
   default = "us-west-2"
 }
 
-variable "create_vpc" {
-  default = true
-}
-
 variable "vpc_name" {
   default = "main-vpc"
 }
 
-# Temporarily here
 variable "vpc_id" {}
+
+variable "igw_id" {}
+
+variable "tags" {
+  type = "map"
+}
 
 variable "azs" {
   type = "list"
 }
 
-# Temporary
-variable "public_subnets" {
+variable "public_subnet_cidrs" {
   type = "list"
 }
 
-variable "private_subnets_cidr" {
+variable "private_subnet_cidrs" {
   type    = "list"
   default = []
 }

--- a/vpc/modules/vpc/main.tf
+++ b/vpc/modules/vpc/main.tf
@@ -1,0 +1,32 @@
+locals {
+  default_tags = {
+    Region    = "${var.region}"
+    Terraform = "true"
+  }
+}
+
+resource "aws_vpc" "this" {
+  cidr_block           = "${var.vpc_cidr}"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = "${merge(local.default_tags, var.tags)}"
+}
+
+resource "aws_vpc_dhcp_options" "this" {
+  domain_name         = "${var.region}.compute.internal"
+  domain_name_servers = ["AmazonProvidedDNS"]
+
+  tags = "${merge(local.default_tags, var.tags)}"
+}
+
+resource "aws_vpc_dhcp_options_association" "this" {
+  vpc_id          = "${aws_vpc.this.id}"
+  dhcp_options_id = "${aws_vpc_dhcp_options.this.id}"
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = "${aws_vpc.this.id}"
+
+  tags = "${merge(local.default_tags, var.tags)}"
+}

--- a/vpc/modules/vpc/outputs.tf
+++ b/vpc/modules/vpc/outputs.tf
@@ -1,0 +1,7 @@
+output "vpc_id" {
+  value = "${aws_vpc.this.id}"
+}
+
+output "igw_id" {
+  value = "${aws_internet_gateway.gw.id}"
+}

--- a/vpc/modules/vpc/variables.tf
+++ b/vpc/modules/vpc/variables.tf
@@ -1,0 +1,12 @@
+
+variable "region" {
+  default = "us-west-2"
+}
+
+variable "vpc_cidr" {
+  default = "172.20.0.0/16"
+}
+
+variable "tags" {
+  type = "map"
+}

--- a/vpc/us-west-2/outputs.tf
+++ b/vpc/us-west-2/outputs.tf
@@ -1,9 +1,9 @@
 output "vpc_id" {
-  value = "${local.vpc_id}"
+  value = "${module.vpc-us-west-2.vpc_id}"
 }
 
 output "public_subnets" {
-  value = "${data.aws_subnet_ids.public_subnets.ids}"
+  value = "${module.subnets-us-west-2.public_subnets}"
 }
 
 output "private_subnets" {


### PR DESCRIPTION
This is an exercise in decoupling the vpc creation from what was
generated by kops. Everything here was rewritten to move the VPC code
generated by kops to its own module.

This brings the VPC more inline to what a standard VPC layout should
look like and it gives us further flexibility moving forward when
creating AWS resources that requires a VPC.

Fixes issue #221 