### PR TITLE
Checking in kops terraform generated code

### DIFF
--- a/k8s/clusters/eu-central-1a/main.tf
+++ b/k8s/clusters/eu-central-1a/main.tf
@@ -21,54 +21,6 @@ module "ark_bucket" {
   cluster_name = "germany"
 }
 
-data aws_route_table "selected" {
-  vpc_id = "${module.kubernetes.vpc_id}"
-
-  filter = {
-    name   = "tag:Name"
-    values = ["k8s.${var.region}*"]
-  }
-}
-
-# This is added after cluster creation
-resource aws_subnet "eu-central-1b-k8s-eu-central-1a-mdn-mozit-cloud" {
-  vpc_id            = "${module.kubernetes.vpc_id}"
-  cidr_block        = "172.20.64.0/19"
-  availability_zone = "eu-central-1b"
-
-  tags = {
-    KubernetesCluster                                         = "k8s.eu-central-1a.mdn.mozit.cloud"
-    Name                                                      = "eu-central-1b.k8s.eu-central-1a.mdn.mozit.cloud"
-    SubnetType                                                = "Public"
-    "kubernetes.io/cluster/k8s.eu-central-1a.mdn.mozit.cloud" = "owned"
-    "kubernetes.io/role/elb"                                  = "1"
-  }
-}
-
-resource "aws_route_table_association" "eu-central-1b-k8s-eu-central-1a-mdn-mozit-cloud" {
-  subnet_id      = "${aws_subnet.eu-central-1b-k8s-eu-central-1a-mdn-mozit-cloud.id}"
-  route_table_id = "${data.aws_route_table.selected.id}"
-}
-
-resource aws_subnet "eu-central-1c-k8s-eu-central-1a-mdn-mozit-cloud" {
-  vpc_id            = "${module.kubernetes.vpc_id}"
-  cidr_block        = "172.20.96.0/19"
-  availability_zone = "eu-central-1c"
-
-  tags = {
-    KubernetesCluster                                         = "k8s.eu-central-1a.mdn.mozit.cloud"
-    Name                                                      = "eu-central-1c.k8s.eu-central-1a.mdn.mozit.cloud"
-    SubnetType                                                = "Public"
-    "kubernetes.io/cluster/k8s.eu-central-1a.mdn.mozit.cloud" = "owned"
-    "kubernetes.io/role/elb"                                  = "1"
-  }
-}
-
-resource aws_route_table_association "eu-central-1c-k8s-eu-central-1a-mdn-mozit-cloud" {
-  subnet_id      = "${aws_subnet.eu-central-1c-k8s-eu-central-1a-mdn-mozit-cloud.id}"
-  route_table_id = "${data.aws_route_table.selected.id}"
-}
-
 # Allow inbound ssh and http from specified IP's
 resource "aws_security_group_rule" "inbound-ssh-to-master" {
   count             = "${length(module.kubernetes.master_security_group_ids)}"

--- a/k8s/clusters/eu-central-1a/out/terraform/data/aws_launch_configuration_master-eu-central-1a.masters.k8s.eu-central-1a.mdn.mozit.cloud_user_data
+++ b/k8s/clusters/eu-central-1a/out/terraform/data/aws_launch_configuration_master-eu-central-1a.masters.k8s.eu-central-1a.mdn.mozit.cloud_user_data
@@ -17,8 +17,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-NODEUP_URL=https://kubeupv2.s3.amazonaws.com/kops/1.11.0/linux/amd64/nodeup
-NODEUP_HASH=6ee282d77600c47ed7744435400e163fa34ee17e
+NODEUP_URL=https://kubeupv2.s3.amazonaws.com/kops/1.11.1/linux/amd64/nodeup
+NODEUP_HASH=d4119d57e89b0a2b6c1200178d9efa890cf2f6b2
 
 export AWS_REGION=eu-central-1
 
@@ -277,7 +277,7 @@ Assets:
 - be55c02936004fb54487e65a18650d9ec17585cb@https://storage.googleapis.com/kubernetes-release/release/v1.11.7/bin/linux/amd64/kubelet
 - 142b72418855b985b8a89e81f17df9d5fb88f1a9@https://storage.googleapis.com/kubernetes-release/release/v1.11.7/bin/linux/amd64/kubectl
 - d595d3ded6499a64e8dac02466e2f5f2ce257c9f@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.6.0.tgz
-- b16b5367e05bad082f416f786c7f8813f7794630@https://kubeupv2.s3.amazonaws.com/kops/1.11.0/linux/amd64/utils.tar.gz
+- b8fef14d3b0594d4c02d6bf94c4fe7329fb7da73@https://kubeupv2.s3.amazonaws.com/kops/1.11.1/linux/amd64/utils.tar.gz
 ClusterName: k8s.eu-central-1a.mdn.mozit.cloud
 ConfigBase: s3://kops-state-4e366a3ac64d1b4022c8b5e35efbd288/k8s.eu-central-1a.mdn.mozit.cloud
 InstanceGroupName: master-eu-central-1a
@@ -287,9 +287,9 @@ Tags:
 channels:
 - s3://kops-state-4e366a3ac64d1b4022c8b5e35efbd288/k8s.eu-central-1a.mdn.mozit.cloud/addons/bootstrap-channel.yaml
 protokubeImage:
-  hash: 725c2de47755544a9aa349e27ed9900d195f0ceb
-  name: protokube:1.11.0
-  source: https://kubeupv2.s3.amazonaws.com/kops/1.11.0/images/protokube.tar.gz
+  hash: 93cc7561bc965e9c754312ed660d6c209586c7a6
+  name: protokube:1.11.1
+  source: https://kubeupv2.s3.amazonaws.com/kops/1.11.1/images/protokube.tar.gz
 
 __EOF_KUBE_ENV
 

--- a/k8s/clusters/eu-central-1a/out/terraform/data/aws_launch_configuration_nodes.k8s.eu-central-1a.mdn.mozit.cloud_user_data
+++ b/k8s/clusters/eu-central-1a/out/terraform/data/aws_launch_configuration_nodes.k8s.eu-central-1a.mdn.mozit.cloud_user_data
@@ -17,8 +17,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-NODEUP_URL=https://kubeupv2.s3.amazonaws.com/kops/1.11.0/linux/amd64/nodeup
-NODEUP_HASH=6ee282d77600c47ed7744435400e163fa34ee17e
+NODEUP_URL=https://kubeupv2.s3.amazonaws.com/kops/1.11.1/linux/amd64/nodeup
+NODEUP_HASH=d4119d57e89b0a2b6c1200178d9efa890cf2f6b2
 
 export AWS_REGION=eu-central-1
 
@@ -191,7 +191,7 @@ Assets:
 - be55c02936004fb54487e65a18650d9ec17585cb@https://storage.googleapis.com/kubernetes-release/release/v1.11.7/bin/linux/amd64/kubelet
 - 142b72418855b985b8a89e81f17df9d5fb88f1a9@https://storage.googleapis.com/kubernetes-release/release/v1.11.7/bin/linux/amd64/kubectl
 - d595d3ded6499a64e8dac02466e2f5f2ce257c9f@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.6.0.tgz
-- b16b5367e05bad082f416f786c7f8813f7794630@https://kubeupv2.s3.amazonaws.com/kops/1.11.0/linux/amd64/utils.tar.gz
+- b8fef14d3b0594d4c02d6bf94c4fe7329fb7da73@https://kubeupv2.s3.amazonaws.com/kops/1.11.1/linux/amd64/utils.tar.gz
 ClusterName: k8s.eu-central-1a.mdn.mozit.cloud
 ConfigBase: s3://kops-state-4e366a3ac64d1b4022c8b5e35efbd288/k8s.eu-central-1a.mdn.mozit.cloud
 InstanceGroupName: nodes
@@ -201,9 +201,9 @@ Tags:
 channels:
 - s3://kops-state-4e366a3ac64d1b4022c8b5e35efbd288/k8s.eu-central-1a.mdn.mozit.cloud/addons/bootstrap-channel.yaml
 protokubeImage:
-  hash: 725c2de47755544a9aa349e27ed9900d195f0ceb
-  name: protokube:1.11.0
-  source: https://kubeupv2.s3.amazonaws.com/kops/1.11.0/images/protokube.tar.gz
+  hash: 93cc7561bc965e9c754312ed660d6c209586c7a6
+  name: protokube:1.11.1
+  source: https://kubeupv2.s3.amazonaws.com/kops/1.11.1/images/protokube.tar.gz
 
 __EOF_KUBE_ENV
 

--- a/k8s/clusters/eu-central-1a/out/terraform/kubernetes.tf
+++ b/k8s/clusters/eu-central-1a/out/terraform/kubernetes.tf
@@ -6,14 +6,13 @@ locals = {
   masters_role_name            = "${aws_iam_role.masters-k8s-eu-central-1a-mdn-mozit-cloud.name}"
   node_autoscaling_group_ids   = ["${aws_autoscaling_group.nodes-k8s-eu-central-1a-mdn-mozit-cloud.id}"]
   node_security_group_ids      = ["${aws_security_group.nodes-k8s-eu-central-1a-mdn-mozit-cloud.id}"]
-  node_subnet_ids              = ["${aws_subnet.eu-central-1a-k8s-eu-central-1a-mdn-mozit-cloud.id}"]
+  node_subnet_ids              = ["subnet-080386f93c0046219"]
   nodes_role_arn               = "${aws_iam_role.nodes-k8s-eu-central-1a-mdn-mozit-cloud.arn}"
   nodes_role_name              = "${aws_iam_role.nodes-k8s-eu-central-1a-mdn-mozit-cloud.name}"
   region                       = "eu-central-1"
-  route_table_public_id        = "${aws_route_table.k8s-eu-central-1a-mdn-mozit-cloud.id}"
-  subnet_eu-central-1a_id      = "${aws_subnet.eu-central-1a-k8s-eu-central-1a-mdn-mozit-cloud.id}"
-  vpc_cidr_block               = "${aws_vpc.k8s-eu-central-1a-mdn-mozit-cloud.cidr_block}"
-  vpc_id                       = "${aws_vpc.k8s-eu-central-1a-mdn-mozit-cloud.id}"
+  subnet_eu-central-1a_id      = "subnet-080386f93c0046219"
+  subnet_ids                   = ["subnet-080386f93c0046219"]
+  vpc_id                       = "vpc-0a0645faca1563b3b"
 }
 
 output "cluster_name" {
@@ -45,7 +44,7 @@ output "node_security_group_ids" {
 }
 
 output "node_subnet_ids" {
-  value = ["${aws_subnet.eu-central-1a-k8s-eu-central-1a-mdn-mozit-cloud.id}"]
+  value = ["subnet-080386f93c0046219"]
 }
 
 output "nodes_role_arn" {
@@ -60,20 +59,16 @@ output "region" {
   value = "eu-central-1"
 }
 
-output "route_table_public_id" {
-  value = "${aws_route_table.k8s-eu-central-1a-mdn-mozit-cloud.id}"
-}
-
 output "subnet_eu-central-1a_id" {
-  value = "${aws_subnet.eu-central-1a-k8s-eu-central-1a-mdn-mozit-cloud.id}"
+  value = "subnet-080386f93c0046219"
 }
 
-output "vpc_cidr_block" {
-  value = "${aws_vpc.k8s-eu-central-1a-mdn-mozit-cloud.cidr_block}"
+output "subnet_ids" {
+  value = ["subnet-080386f93c0046219"]
 }
 
 output "vpc_id" {
-  value = "${aws_vpc.k8s-eu-central-1a-mdn-mozit-cloud.id}"
+  value = "vpc-0a0645faca1563b3b"
 }
 
 provider "aws" {
@@ -85,7 +80,7 @@ resource "aws_autoscaling_group" "master-eu-central-1a-masters-k8s-eu-central-1a
   launch_configuration = "${aws_launch_configuration.master-eu-central-1a-masters-k8s-eu-central-1a-mdn-mozit-cloud.id}"
   max_size             = 1
   min_size             = 1
-  vpc_zone_identifier  = ["${aws_subnet.eu-central-1a-k8s-eu-central-1a-mdn-mozit-cloud.id}"]
+  vpc_zone_identifier  = ["subnet-080386f93c0046219"]
 
   tag = {
     key                 = "KubernetesCluster"
@@ -120,7 +115,7 @@ resource "aws_autoscaling_group" "nodes-k8s-eu-central-1a-mdn-mozit-cloud" {
   launch_configuration = "${aws_launch_configuration.nodes-k8s-eu-central-1a-mdn-mozit-cloud.id}"
   max_size             = 3
   min_size             = 3
-  vpc_zone_identifier  = ["${aws_subnet.eu-central-1a-k8s-eu-central-1a-mdn-mozit-cloud.id}"]
+  vpc_zone_identifier  = ["subnet-080386f93c0046219"]
 
   tag = {
     key                 = "KubernetesCluster"
@@ -212,16 +207,6 @@ resource "aws_iam_role_policy" "nodes-k8s-eu-central-1a-mdn-mozit-cloud" {
   policy = "${file("${path.module}/data/aws_iam_role_policy_nodes.k8s.eu-central-1a.mdn.mozit.cloud_policy")}"
 }
 
-resource "aws_internet_gateway" "k8s-eu-central-1a-mdn-mozit-cloud" {
-  vpc_id = "${aws_vpc.k8s-eu-central-1a-mdn-mozit-cloud.id}"
-
-  tags = {
-    KubernetesCluster                                         = "k8s.eu-central-1a.mdn.mozit.cloud"
-    Name                                                      = "k8s.eu-central-1a.mdn.mozit.cloud"
-    "kubernetes.io/cluster/k8s.eu-central-1a.mdn.mozit.cloud" = "owned"
-  }
-}
-
 resource "aws_key_pair" "kubernetes-k8s-eu-central-1a-mdn-mozit-cloud-44ff04d0bf8934c5c30d253bd7df3bef" {
   key_name   = "kubernetes.k8s.eu-central-1a.mdn.mozit.cloud-44:ff:04:d0:bf:89:34:c5:c3:0d:25:3b:d7:df:3b:ef"
   public_key = "${file("${path.module}/data/aws_key_pair_kubernetes.k8s.eu-central-1a.mdn.mozit.cloud-44ff04d0bf8934c5c30d253bd7df3bef_public_key")}"
@@ -273,31 +258,9 @@ resource "aws_launch_configuration" "nodes-k8s-eu-central-1a-mdn-mozit-cloud" {
   enable_monitoring = false
 }
 
-resource "aws_route" "0-0-0-0--0" {
-  route_table_id         = "${aws_route_table.k8s-eu-central-1a-mdn-mozit-cloud.id}"
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.k8s-eu-central-1a-mdn-mozit-cloud.id}"
-}
-
-resource "aws_route_table" "k8s-eu-central-1a-mdn-mozit-cloud" {
-  vpc_id = "${aws_vpc.k8s-eu-central-1a-mdn-mozit-cloud.id}"
-
-  tags = {
-    KubernetesCluster                                         = "k8s.eu-central-1a.mdn.mozit.cloud"
-    Name                                                      = "k8s.eu-central-1a.mdn.mozit.cloud"
-    "kubernetes.io/cluster/k8s.eu-central-1a.mdn.mozit.cloud" = "owned"
-    "kubernetes.io/kops/role"                                 = "public"
-  }
-}
-
-resource "aws_route_table_association" "eu-central-1a-k8s-eu-central-1a-mdn-mozit-cloud" {
-  subnet_id      = "${aws_subnet.eu-central-1a-k8s-eu-central-1a-mdn-mozit-cloud.id}"
-  route_table_id = "${aws_route_table.k8s-eu-central-1a-mdn-mozit-cloud.id}"
-}
-
 resource "aws_security_group" "masters-k8s-eu-central-1a-mdn-mozit-cloud" {
   name        = "masters.k8s.eu-central-1a.mdn.mozit.cloud"
-  vpc_id      = "${aws_vpc.k8s-eu-central-1a-mdn-mozit-cloud.id}"
+  vpc_id      = "vpc-0a0645faca1563b3b"
   description = "Security group for masters"
 
   tags = {
@@ -309,7 +272,7 @@ resource "aws_security_group" "masters-k8s-eu-central-1a-mdn-mozit-cloud" {
 
 resource "aws_security_group" "nodes-k8s-eu-central-1a-mdn-mozit-cloud" {
   name        = "nodes.k8s.eu-central-1a.mdn.mozit.cloud"
-  vpc_id      = "${aws_vpc.k8s-eu-central-1a-mdn-mozit-cloud.id}"
+  vpc_id      = "vpc-0a0645faca1563b3b"
   description = "Security group for nodes"
 
   tags = {
@@ -435,48 +398,6 @@ resource "aws_security_group_rule" "node-to-master-udp-1-65535" {
 #  protocol          = "tcp"
 #  cidr_blocks       = ["0.0.0.0/0"]
 #}
-
-resource "aws_subnet" "eu-central-1a-k8s-eu-central-1a-mdn-mozit-cloud" {
-  vpc_id            = "${aws_vpc.k8s-eu-central-1a-mdn-mozit-cloud.id}"
-  cidr_block        = "172.20.32.0/19"
-  availability_zone = "eu-central-1a"
-
-  tags = {
-    KubernetesCluster                                         = "k8s.eu-central-1a.mdn.mozit.cloud"
-    Name                                                      = "eu-central-1a.k8s.eu-central-1a.mdn.mozit.cloud"
-    SubnetType                                                = "Public"
-    "kubernetes.io/cluster/k8s.eu-central-1a.mdn.mozit.cloud" = "owned"
-    "kubernetes.io/role/elb"                                  = "1"
-  }
-}
-
-resource "aws_vpc" "k8s-eu-central-1a-mdn-mozit-cloud" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
-
-  tags = {
-    KubernetesCluster                                         = "k8s.eu-central-1a.mdn.mozit.cloud"
-    Name                                                      = "k8s.eu-central-1a.mdn.mozit.cloud"
-    "kubernetes.io/cluster/k8s.eu-central-1a.mdn.mozit.cloud" = "owned"
-  }
-}
-
-resource "aws_vpc_dhcp_options" "k8s-eu-central-1a-mdn-mozit-cloud" {
-  domain_name         = "eu-central-1.compute.internal"
-  domain_name_servers = ["AmazonProvidedDNS"]
-
-  tags = {
-    KubernetesCluster                                         = "k8s.eu-central-1a.mdn.mozit.cloud"
-    Name                                                      = "k8s.eu-central-1a.mdn.mozit.cloud"
-    "kubernetes.io/cluster/k8s.eu-central-1a.mdn.mozit.cloud" = "owned"
-  }
-}
-
-resource "aws_vpc_dhcp_options_association" "k8s-eu-central-1a-mdn-mozit-cloud" {
-  vpc_id          = "${aws_vpc.k8s-eu-central-1a-mdn-mozit-cloud.id}"
-  dhcp_options_id = "${aws_vpc_dhcp_options.k8s-eu-central-1a-mdn-mozit-cloud.id}"
-}
 
 terraform = {
   required_version = ">= 0.9.3"

--- a/k8s/clusters/us-west-2a/main.tf
+++ b/k8s/clusters/us-west-2a/main.tf
@@ -21,40 +21,6 @@ module "ark_bucket" {
   cluster_name = "oregon-a"
 }
 
-# These are added here after terraform creates the kube cluster
-# because we create a single AZ cluster, only subnet gets created.
-# and that in turn makes things like RDS grumpy. So we import this after the fact
-#
-# terraform import aws_subnet.us-west-2b-k8s-us-west-2b-mdn-mozit-cloud <subnet id>
-
-resource aws_subnet "us-west-2b-k8s-us-west-2a-mdn-mozit-cloud" {
-  vpc_id            = "${module.kubernetes.vpc_id}"
-  cidr_block        = "172.20.64.0/19"
-  availability_zone = "us-west-2b"
-
-  tags = {
-    KubernetesCluster                                      = "k8s.us-west-2a.mdn.mozit.cloud"
-    Name                                                   = "us-west-2b.k8s.us-west-2a.mdn.mozit.cloud"
-    SubnetType                                             = "Public"
-    "kubernetes.io/cluster/k8s.us-west-2a.mdn.mozit.cloud" = "owned"
-    "kubernetes.io/role/elb"                               = "1"
-  }
-}
-
-resource aws_subnet "us-west-2c-k8s-us-west-2a-mdn-mozit-cloud" {
-  vpc_id            = "${module.kubernetes.vpc_id}"
-  cidr_block        = "172.20.96.0/19"
-  availability_zone = "us-west-2c"
-
-  tags = {
-    KubernetesCluster                                      = "k8s.us-west-2a.mdn.mozit.cloud"
-    Name                                                   = "us-west-2c.k8s.us-west-2a.mdn.mozit.cloud"
-    SubnetType                                             = "Public"
-    "kubernetes.io/cluster/k8s.us-west-2a.mdn.mozit.cloud" = "owned"
-    "kubernetes.io/role/elb"                               = "1"
-  }
-}
-
 # Allow inbound ssh and http from specified IP's
 resource "aws_security_group_rule" "inbound-ssh-to-master" {
   count             = "${length(module.kubernetes.master_security_group_ids)}"

--- a/k8s/clusters/us-west-2a/out/terraform/kubernetes.tf
+++ b/k8s/clusters/us-west-2a/out/terraform/kubernetes.tf
@@ -6,14 +6,13 @@ locals = {
   masters_role_name            = "${aws_iam_role.masters-k8s-us-west-2a-mdn-mozit-cloud.name}"
   node_autoscaling_group_ids   = ["${aws_autoscaling_group.nodes-k8s-us-west-2a-mdn-mozit-cloud.id}"]
   node_security_group_ids      = ["${aws_security_group.nodes-k8s-us-west-2a-mdn-mozit-cloud.id}"]
-  node_subnet_ids              = ["${aws_subnet.us-west-2a-k8s-us-west-2a-mdn-mozit-cloud.id}"]
+  node_subnet_ids              = ["subnet-4890e603"]
   nodes_role_arn               = "${aws_iam_role.nodes-k8s-us-west-2a-mdn-mozit-cloud.arn}"
   nodes_role_name              = "${aws_iam_role.nodes-k8s-us-west-2a-mdn-mozit-cloud.name}"
   region                       = "us-west-2"
-  route_table_public_id        = "${aws_route_table.k8s-us-west-2a-mdn-mozit-cloud.id}"
-  subnet_us-west-2a_id         = "${aws_subnet.us-west-2a-k8s-us-west-2a-mdn-mozit-cloud.id}"
-  vpc_cidr_block               = "${aws_vpc.k8s-us-west-2a-mdn-mozit-cloud.cidr_block}"
-  vpc_id                       = "${aws_vpc.k8s-us-west-2a-mdn-mozit-cloud.id}"
+  subnet_ids                   = ["subnet-4890e603"]
+  subnet_us-west-2a_id         = "subnet-4890e603"
+  vpc_id                       = "vpc-8c768ef4"
 }
 
 output "cluster_name" {
@@ -45,7 +44,7 @@ output "node_security_group_ids" {
 }
 
 output "node_subnet_ids" {
-  value = ["${aws_subnet.us-west-2a-k8s-us-west-2a-mdn-mozit-cloud.id}"]
+  value = ["subnet-4890e603"]
 }
 
 output "nodes_role_arn" {
@@ -60,20 +59,16 @@ output "region" {
   value = "us-west-2"
 }
 
-output "route_table_public_id" {
-  value = "${aws_route_table.k8s-us-west-2a-mdn-mozit-cloud.id}"
+output "subnet_ids" {
+  value = ["subnet-4890e603"]
 }
 
 output "subnet_us-west-2a_id" {
-  value = "${aws_subnet.us-west-2a-k8s-us-west-2a-mdn-mozit-cloud.id}"
-}
-
-output "vpc_cidr_block" {
-  value = "${aws_vpc.k8s-us-west-2a-mdn-mozit-cloud.cidr_block}"
+  value = "subnet-4890e603"
 }
 
 output "vpc_id" {
-  value = "${aws_vpc.k8s-us-west-2a-mdn-mozit-cloud.id}"
+  value = "vpc-8c768ef4"
 }
 
 provider "aws" {
@@ -85,7 +80,7 @@ resource "aws_autoscaling_group" "master-us-west-2a-masters-k8s-us-west-2a-mdn-m
   launch_configuration = "${aws_launch_configuration.master-us-west-2a-masters-k8s-us-west-2a-mdn-mozit-cloud.id}"
   max_size             = 1
   min_size             = 1
-  vpc_zone_identifier  = ["${aws_subnet.us-west-2a-k8s-us-west-2a-mdn-mozit-cloud.id}"]
+  vpc_zone_identifier  = ["subnet-4890e603"]
 
   tag = {
     key                 = "KubernetesCluster"
@@ -120,7 +115,7 @@ resource "aws_autoscaling_group" "nodes-k8s-us-west-2a-mdn-mozit-cloud" {
   launch_configuration = "${aws_launch_configuration.nodes-k8s-us-west-2a-mdn-mozit-cloud.id}"
   max_size             = 15
   min_size             = 12
-  vpc_zone_identifier  = ["${aws_subnet.us-west-2a-k8s-us-west-2a-mdn-mozit-cloud.id}"]
+  vpc_zone_identifier  = ["subnet-4890e603"]
 
   tag = {
     key                 = "KubernetesCluster"
@@ -212,16 +207,6 @@ resource "aws_iam_role_policy" "nodes-k8s-us-west-2a-mdn-mozit-cloud" {
   policy = "${file("${path.module}/data/aws_iam_role_policy_nodes.k8s.us-west-2a.mdn.mozit.cloud_policy")}"
 }
 
-resource "aws_internet_gateway" "k8s-us-west-2a-mdn-mozit-cloud" {
-  vpc_id = "${aws_vpc.k8s-us-west-2a-mdn-mozit-cloud.id}"
-
-  tags = {
-    KubernetesCluster                                      = "k8s.us-west-2a.mdn.mozit.cloud"
-    Name                                                   = "k8s.us-west-2a.mdn.mozit.cloud"
-    "kubernetes.io/cluster/k8s.us-west-2a.mdn.mozit.cloud" = "owned"
-  }
-}
-
 resource "aws_key_pair" "kubernetes-k8s-us-west-2a-mdn-mozit-cloud-44ff04d0bf8934c5c30d253bd7df3bef" {
   key_name   = "kubernetes.k8s.us-west-2a.mdn.mozit.cloud-44:ff:04:d0:bf:89:34:c5:c3:0d:25:3b:d7:df:3b:ef"
   public_key = "${file("${path.module}/data/aws_key_pair_kubernetes.k8s.us-west-2a.mdn.mozit.cloud-44ff04d0bf8934c5c30d253bd7df3bef_public_key")}"
@@ -273,31 +258,9 @@ resource "aws_launch_configuration" "nodes-k8s-us-west-2a-mdn-mozit-cloud" {
   enable_monitoring = false
 }
 
-resource "aws_route" "0-0-0-0--0" {
-  route_table_id         = "${aws_route_table.k8s-us-west-2a-mdn-mozit-cloud.id}"
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.k8s-us-west-2a-mdn-mozit-cloud.id}"
-}
-
-resource "aws_route_table" "k8s-us-west-2a-mdn-mozit-cloud" {
-  vpc_id = "${aws_vpc.k8s-us-west-2a-mdn-mozit-cloud.id}"
-
-  tags = {
-    KubernetesCluster                                      = "k8s.us-west-2a.mdn.mozit.cloud"
-    Name                                                   = "k8s.us-west-2a.mdn.mozit.cloud"
-    "kubernetes.io/cluster/k8s.us-west-2a.mdn.mozit.cloud" = "owned"
-    "kubernetes.io/kops/role"                              = "public"
-  }
-}
-
-resource "aws_route_table_association" "us-west-2a-k8s-us-west-2a-mdn-mozit-cloud" {
-  subnet_id      = "${aws_subnet.us-west-2a-k8s-us-west-2a-mdn-mozit-cloud.id}"
-  route_table_id = "${aws_route_table.k8s-us-west-2a-mdn-mozit-cloud.id}"
-}
-
 resource "aws_security_group" "masters-k8s-us-west-2a-mdn-mozit-cloud" {
   name        = "masters.k8s.us-west-2a.mdn.mozit.cloud"
-  vpc_id      = "${aws_vpc.k8s-us-west-2a-mdn-mozit-cloud.id}"
+  vpc_id      = "vpc-8c768ef4"
   description = "Security group for masters"
 
   tags = {
@@ -309,7 +272,7 @@ resource "aws_security_group" "masters-k8s-us-west-2a-mdn-mozit-cloud" {
 
 resource "aws_security_group" "nodes-k8s-us-west-2a-mdn-mozit-cloud" {
   name        = "nodes.k8s.us-west-2a.mdn.mozit.cloud"
-  vpc_id      = "${aws_vpc.k8s-us-west-2a-mdn-mozit-cloud.id}"
+  vpc_id      = "vpc-8c768ef4"
   description = "Security group for nodes"
 
   tags = {
@@ -435,48 +398,6 @@ resource "aws_security_group_rule" "node-to-master-udp-1-65535" {
 #  protocol          = "tcp"
 #  cidr_blocks       = ["0.0.0.0/0"]
 #}
-
-resource "aws_subnet" "us-west-2a-k8s-us-west-2a-mdn-mozit-cloud" {
-  vpc_id            = "${aws_vpc.k8s-us-west-2a-mdn-mozit-cloud.id}"
-  cidr_block        = "172.20.32.0/19"
-  availability_zone = "us-west-2a"
-
-  tags = {
-    KubernetesCluster                                      = "k8s.us-west-2a.mdn.mozit.cloud"
-    Name                                                   = "us-west-2a.k8s.us-west-2a.mdn.mozit.cloud"
-    SubnetType                                             = "Public"
-    "kubernetes.io/cluster/k8s.us-west-2a.mdn.mozit.cloud" = "owned"
-    "kubernetes.io/role/elb"                               = "1"
-  }
-}
-
-resource "aws_vpc" "k8s-us-west-2a-mdn-mozit-cloud" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
-
-  tags = {
-    KubernetesCluster                                      = "k8s.us-west-2a.mdn.mozit.cloud"
-    Name                                                   = "k8s.us-west-2a.mdn.mozit.cloud"
-    "kubernetes.io/cluster/k8s.us-west-2a.mdn.mozit.cloud" = "owned"
-  }
-}
-
-resource "aws_vpc_dhcp_options" "k8s-us-west-2a-mdn-mozit-cloud" {
-  domain_name         = "us-west-2.compute.internal"
-  domain_name_servers = ["AmazonProvidedDNS"]
-
-  tags = {
-    KubernetesCluster                                      = "k8s.us-west-2a.mdn.mozit.cloud"
-    Name                                                   = "k8s.us-west-2a.mdn.mozit.cloud"
-    "kubernetes.io/cluster/k8s.us-west-2a.mdn.mozit.cloud" = "owned"
-  }
-}
-
-resource "aws_vpc_dhcp_options_association" "k8s-us-west-2a-mdn-mozit-cloud" {
-  vpc_id          = "${aws_vpc.k8s-us-west-2a-mdn-mozit-cloud.id}"
-  dhcp_options_id = "${aws_vpc_dhcp_options.k8s-us-west-2a-mdn-mozit-cloud.id}"
-}
 
 terraform = {
   required_version = ">= 0.9.3"

--- a/vpc/eu-central-1/main.tf
+++ b/vpc/eu-central-1/main.tf
@@ -17,11 +17,11 @@ locals {
   vpc_tags = {
     Name                                                      = "k8s.eu-central-1a.mdn.mozit.cloud"
     KubernetesCluster                                         = "k8s.eu-central-1a.mdn.mozit.cloud"
-    "kubernetes.io/cluster/k8s.eu-central-1a.mdn.mozit.cloud" = "owned"
+    "kubernetes.io/cluster/k8s.eu-central-1a.mdn.mozit.cloud" = "shared"
   }
 
   subnet_tags = {
-    "kubernetes.io/cluster/k8s.eu-central-1a.mdn.mozit.cloud" = "owned"
+    "kubernetes.io/cluster/k8s.eu-central-1a.mdn.mozit.cloud" = "shared"
   }
 }
 

--- a/vpc/us-west-2/main.tf
+++ b/vpc/us-west-2/main.tf
@@ -17,11 +17,11 @@ locals {
   vpc_tags = {
     Name                                                   = "k8s.us-west-2a.mdn.mozit.cloud"
     KubernetesCluster                                      = "k8s.us-west-2a.mdn.mozit.cloud"
-    "kubernetes.io/cluster/k8s.us-west-2a.mdn.mozit.cloud" = "owned"
+    "kubernetes.io/cluster/k8s.us-west-2a.mdn.mozit.cloud" = "shared"
   }
 
   subnet_tags = {
-    "kubernetes.io/cluster/k8s.us-west-2a.mdn.mozit.cloud" = "owned"
+    "kubernetes.io/cluster/k8s.us-west-2a.mdn.mozit.cloud" = "shared"
   }
 }
 


### PR DESCRIPTION
Continuing work on the decoupling of vpc creation from kops. The clusters specs have now been updated to use the existing vpc and subnet instead of generating a VPC.