### PR TITLE
Switching variables in terraform to point to the state location

### DIFF
--- a/apps/mdn/mdn-aws/infra/data.tf
+++ b/apps/mdn/mdn-aws/infra/data.tf
@@ -13,35 +13,52 @@ data terraform_remote_state "dns" {
   }
 }
 
-data terraform_remote_state "kubernetes-us-west-2" {
+data terraform_remote_state "vpc-us-west-2" {
   backend = "s3"
 
   config {
     bucket = "mdn-state-4e366a3ac64d1b4022c8b5e35efbd288"
-    key    = "terraform/kubernetes-us-west-2a"
+    key    = "terraform/us-west-2/vpc"
     region = "us-west-2"
   }
 }
 
-data terraform_remote_state "kubernetes-eu-central-1" {
+data terraform_remote_state "vpc-eu-central-1" {
   backend = "s3"
 
-  config  = {
-    bucket  = "mdn-state-4e366a3ac64d1b4022c8b5e35efbd288"
-    key     = "terraform/kubernetes-eu-central-1a"
-    region  = "us-west-2"
+  config = {
+    bucket = "mdn-state-4e366a3ac64d1b4022c8b5e35efbd288"
+    key    = "terraform/eu-central-1/vpc"
+    region = "us-west-2"
   }
 }
 
 data aws_vpc "cidr" {
-  id = "${data.terraform_remote_state.kubernetes-us-west-2.vpc_id}"
+  id = "${data.terraform_remote_state.vpc-us-west-2.vpc_id}"
 }
 
-data aws_subnet_ids "subnet_id" {
-  vpc_id = "${data.terraform_remote_state.kubernetes-us-west-2.vpc_id}"
+data "aws_security_groups" "us-west-2-nodes_sg" {
+  filter {
+    name   = "group-name"
+    values = ["nodes.k8s.us-west-2*"]
+  }
+
+  filter {
+    name   = "vpc-id"
+    values = ["${data.terraform_remote_state.vpc-us-west-2.vpc_id}"]
+  }
 }
 
-data aws_subnet_ids "eu-central-subnet_ids" {
+data "aws_security_groups" "eu-central-1-nodes_sg" {
   provider = "aws.data-eu-central-1"
-  vpc_id  = "${data.terraform_remote_state.kubernetes-eu-central-1.vpc_id}"
+
+  filter {
+    name   = "group-name"
+    values = ["nodes.k8s.eu-central-1*"]
+  }
+
+  filter {
+    name   = "vpc-id"
+    values = ["${data.terraform_remote_state.vpc-eu-central-1.vpc_id}"]
+  }
 }

--- a/apps/mdn/mdn-aws/infra/main.tf
+++ b/apps/mdn/mdn-aws/infra/main.tf
@@ -28,7 +28,7 @@ module "rds-backups" {
 
 module "security" {
   source           = "./modules/security"
-  us-west-2-vpc-id = "${data.terraform_remote_state.kubernetes-us-west-2.vpc_id}"
+  us-west-2-vpc-id = "${data.terraform_remote_state.vpc-us-west-2.vpc_id}"
 }
 
 module "mdn_cdn" {
@@ -88,8 +88,8 @@ module "efs-us-west-2" {
   environment          = "stage"
   region               = "us-west-2"
   efs_name             = "stage"
-  subnets              = "${join(",", data.terraform_remote_state.kubernetes-us-west-2.node_subnet_ids)}"
-  nodes_security_group = "${data.terraform_remote_state.kubernetes-us-west-2.node_security_group_ids}"
+  subnets              = "${join(",", data.terraform_remote_state.vpc-us-west-2.public_subnets)}"
+  nodes_security_group = "${data.aws_security_groups.us-west-2-nodes_sg.ids}"
 }
 
 module "efs-us-west-2-prod" {
@@ -98,8 +98,8 @@ module "efs-us-west-2-prod" {
   environment          = "prod"
   region               = "us-west-2"
   efs_name             = "prod"
-  subnets              = "${join(",", data.terraform_remote_state.kubernetes-us-west-2.node_subnet_ids)}"
-  nodes_security_group = "${data.terraform_remote_state.kubernetes-us-west-2.node_security_group_ids}"
+  subnets              = "${join(",", data.terraform_remote_state.vpc-us-west-2.public_subnets)}"
+  nodes_security_group = "${data.aws_security_groups.us-west-2-nodes_sg.ids}"
 }
 
 module "efs-eu-central-1-prod" {
@@ -108,8 +108,8 @@ module "efs-eu-central-1-prod" {
   environment          = "prod"
   region               = "eu-central-1"
   efs_name             = "prod"
-  subnets              = "${join(",", data.terraform_remote_state.kubernetes-eu-central-1.node_subnet_ids)}"
-  nodes_security_group = "${data.terraform_remote_state.kubernetes-eu-central-1.node_security_group_ids}"
+  subnets              = "${join(",", data.terraform_remote_state.vpc-eu-central-1.public_subnets)}"
+  nodes_security_group = "${data.aws_security_groups.eu-central-1-nodes_sg.ids}"
 }
 
 module "redis-us-west-2" {
@@ -120,8 +120,8 @@ module "redis-us-west-2" {
   redis_name           = "stage"
   redis_node_size      = "${lookup(var.redis, "node_size.stage")}"
   redis_num_nodes      = "${lookup(var.redis, "num_nodes.stage")}"
-  subnets              = "${join(",", data.terraform_remote_state.kubernetes-us-west-2.node_subnet_ids)}"
-  nodes_security_group = "${data.terraform_remote_state.kubernetes-us-west-2.node_security_group_ids}"
+  subnets              = "${join(",", data.terraform_remote_state.vpc-us-west-2.public_subnets)}"
+  nodes_security_group = "${data.aws_security_groups.us-west-2-nodes_sg.ids}"
 }
 
 module "redis-us-west-2-prod" {
@@ -132,8 +132,8 @@ module "redis-us-west-2-prod" {
   redis_name           = "prod"
   redis_node_size      = "${lookup(var.redis, "node_size.prod")}"
   redis_num_nodes      = "${lookup(var.redis, "num_nodes.prod")}"
-  subnets              = "${join(",", data.terraform_remote_state.kubernetes-us-west-2.node_subnet_ids)}"
-  nodes_security_group = "${data.terraform_remote_state.kubernetes-us-west-2.node_security_group_ids}"
+  subnets              = "${join(",", data.terraform_remote_state.vpc-us-west-2.public_subnets)}"
+  nodes_security_group = "${data.aws_security_groups.us-west-2-nodes_sg.ids}"
 }
 
 module "redis-eu-central-1-prod" {
@@ -144,8 +144,8 @@ module "redis-eu-central-1-prod" {
   redis_name           = "prod"
   redis_node_size      = "${lookup(var.redis, "node_size.prod")}"
   redis_num_nodes      = "${lookup(var.redis, "num_nodes.prod")}"
-  subnets              = "${join(",", data.terraform_remote_state.kubernetes-eu-central-1.node_subnet_ids)}"
-  nodes_security_group = "${data.terraform_remote_state.kubernetes-eu-central-1.node_security_group_ids}"
+  subnets              = "${join(",", data.terraform_remote_state.vpc-eu-central-1.public_subnets)}"
+  nodes_security_group = "${data.aws_security_groups.eu-central-1-nodes_sg.ids}"
 }
 
 module "mysql-us-west-2" {
@@ -164,9 +164,9 @@ module "mysql-us-west-2" {
   mysql_security_group_name   = "mdn_rds_sg_stage"
   mysql_storage_gb            = "${lookup(var.rds, "storage_gb.stage")}"
   mysql_storage_type          = "${lookup(var.rds, "storage_type")}"
-  vpc_id                      = "${data.terraform_remote_state.kubernetes-us-west-2.vpc_id}"
+  vpc_id                      = "${data.terraform_remote_state.vpc-us-west-2.vpc_id}"
   vpc_cidr                    = "${data.aws_vpc.cidr.cidr_block}"
-  subnets                     = "${join(",", data.aws_subnet_ids.subnet_id.ids)}"
+  subnets                     = "${join(",", data.terraform_remote_state.vpc-us-west-2.public_subnets)}"
   monitoring_interval         = "60"
 }
 
@@ -186,9 +186,9 @@ module "mysql-us-west-2-prod" {
   mysql_security_group_name   = "mdn_rds_sg_prod"
   mysql_storage_gb            = "${lookup(var.rds, "storage_gb.prod")}"
   mysql_storage_type          = "${lookup(var.rds, "storage_type")}"
-  vpc_id                      = "${data.terraform_remote_state.kubernetes-us-west-2.vpc_id}"
+  vpc_id                      = "${data.terraform_remote_state.vpc-us-west-2.vpc_id}"
   vpc_cidr                    = "${data.aws_vpc.cidr.cidr_block}"
-  subnets                     = "${join(",", data.aws_subnet_ids.subnet_id.ids)}"
+  subnets                     = "${join(",", data.terraform_remote_state.vpc-us-west-2.public_subnets)}"
   monitoring_interval         = "60"
 }
 
@@ -197,10 +197,10 @@ module "mysql-eu-central-1-replica-prod" {
   source              = "./modules/multi_region/rds-replica"
   environment         = "prod"
   region              = "eu-central-1"
-  subnets             = "${join(",", data.aws_subnet_ids.eu-central-subnet_ids.ids)}"
+  subnets             = "${join(",", data.terraform_remote_state.vpc-eu-central-1.public_subnets)}"
   replica_source_db   = "${module.mysql-us-west-2-prod.rds_arn}"
-  vpc_id              = "${data.terraform_remote_state.kubernetes-eu-central-1.vpc_id}"
-  kms_key_id          = "${lookup(var.rds, "key_id.eu-central-1")}"                     # Less than ideal this key is copied from the console
+  vpc_id              = "${data.terraform_remote_state.vpc-eu-central-1.vpc_id}"
+  kms_key_id          = "${lookup(var.rds, "key_id.eu-central-1")}"                                 # Less than ideal this key is copied from the console
   instance_class      = "${lookup(var.rds, "instance_class.prod")}"
   monitoring_interval = "60"
 }

--- a/apps/mdn/mdn-samples/data.tf
+++ b/apps/mdn/mdn-samples/data.tf
@@ -1,15 +1,11 @@
-data terraform_remote_state "kubernetes-us-west-2" {
+data terraform_remote_state "vpc-us-west-2" {
   backend = "s3"
 
   config {
     bucket = "mdn-state-4e366a3ac64d1b4022c8b5e35efbd288"
-    key    = "terraform/kubernetes-us-west-2a"
+    key    = "terraform/us-west-2/vpc"
     region = "us-west-2"
   }
-}
-
-data aws_subnet_ids "subnet_id" {
-  vpc_id = "${data.terraform_remote_state.kubernetes-us-west-2.vpc_id}"
 }
 
 data aws_ami "centos" {

--- a/apps/mdn/mdn-samples/main.tf
+++ b/apps/mdn/mdn-samples/main.tf
@@ -27,7 +27,7 @@ resource "aws_security_group" "mdn-samples" {
   name        = "mdn-samples-sg"
   description = "Allow inbound traffic to mdn-samples"
 
-  vpc_id = "${data.terraform_remote_state.kubernetes-us-west-2.vpc_id}"
+  vpc_id = "${data.terraform_remote_state.vpc-us-west-2.vpc_id}"
 
   ingress {
     from_port   = 443
@@ -96,7 +96,7 @@ data "template_cloudinit_config" "config" {
 }
 
 resource "aws_autoscaling_group" "mdn-samples" {
-  vpc_zone_identifier = ["${data.aws_subnet_ids.subnet_id.ids}"]
+  vpc_zone_identifier = ["${data.terraform_remote_state.vpc-us-west-2.public_subnets}"]
 
   name = "mdn-samples - ${aws_launch_configuration.mdn-samples.name}"
 

--- a/jenkins/infra/terraform/data.tf
+++ b/jenkins/infra/terraform/data.tf
@@ -1,15 +1,11 @@
-data terraform_remote_state "kubernetes-us-west-2" {
+data terraform_remote_state "vpc-us-west-2" {
   backend = "s3"
 
   config {
     bucket = "mdn-state-4e366a3ac64d1b4022c8b5e35efbd288"
-    key    = "terraform/kubernetes-us-west-2a"
+    key    = "terraform/us-west-2/vpc"
     region = "us-west-2"
   }
-}
-
-data aws_subnet_ids "subnet_id" {
-  vpc_id = "${data.terraform_remote_state.kubernetes-us-west-2.vpc_id}"
 }
 
 data aws_ami "ubuntu" {

--- a/jenkins/infra/terraform/main.tf
+++ b/jenkins/infra/terraform/main.tf
@@ -33,7 +33,7 @@ resource "aws_eip" "ci-eip" {
 # Create a new load balancer
 resource "aws_elb" "ci" {
   name    = "ci-elb-${var.project}"
-  subnets = ["${data.aws_subnet_ids.subnet_id.ids}"]
+  subnets = ["${data.terraform_remote_state.vpc-us-west-2.public_subnets}"]
 
   listener {
     instance_port     = 80
@@ -74,7 +74,7 @@ resource "aws_security_group" "elb" {
   name        = "ci-elb-sg"
   description = "Allow inbound traffic from ELB to CI"
 
-  vpc_id = "${data.terraform_remote_state.kubernetes-us-west-2.vpc_id}"
+  vpc_id = "${data.terraform_remote_state.vpc-us-west-2.vpc_id}"
 
   egress {
     from_port   = 0
@@ -113,7 +113,7 @@ resource "aws_security_group" "ci" {
   name        = "ci-sg"
   description = "Allow inbound traffic to CI from ELB"
 
-  vpc_id = "${data.terraform_remote_state.kubernetes-us-west-2.vpc_id}"
+  vpc_id = "${data.terraform_remote_state.vpc-us-west-2.vpc_id}"
 
   ingress {
     from_port = 80
@@ -177,7 +177,7 @@ resource "aws_security_group_rule" "ingress_ssh" {
 }
 
 resource "aws_autoscaling_group" "ci" {
-  vpc_zone_identifier = ["${data.aws_subnet_ids.subnet_id.ids}"]
+  vpc_zone_identifier = ["${data.terraform_remote_state.vpc-us-west-2.public_subnets}"]
 
   # This is on purpose, when the LC changes, will force creation of a new ASG
   name = "ci-${var.project} - ${aws_launch_configuration.ci.name}"


### PR DESCRIPTION
The variable vpc_id and subnet_ids are all located elsewhere now since refactoring the VPC code. This is a continuation of issue #221 