### PR TITLE
add mdn_api celery queue

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -66,7 +66,7 @@ export CELERY_WORKERS_CPU_REQUEST ?= 100m
 export CELERY_WORKERS_MEMORY_LIMIT ?= 4Gi
 export CELERY_WORKERS_MEMORY_REQUEST ?= 256Mi
 export CELERY_WORKERS_CONCURRENCY ?= 4
-export CELERY_WORKERS_QUEUES ?= mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,celery
+export CELERY_WORKERS_QUEUES ?= mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,mdn_api,celery
 
 export CELERY_BEAT_NAME ?= celery-beat
 export CELERY_BEAT_REPLICAS ?= 1

--- a/apps/mdn/mdn-aws/k8s/regions/germany/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/germany/prod.mm.sh
@@ -69,7 +69,7 @@ export CELERY_WORKERS_CPU_REQUEST=500m
 export CELERY_WORKERS_MEMORY_LIMIT=4Gi
 export CELERY_WORKERS_MEMORY_REQUEST=2Gi
 export CELERY_WORKERS_CONCURRENCY=4
-export CELERY_WORKERS_QUEUES=mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,celery
+export CELERY_WORKERS_QUEUES=mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,mdn_api,celery
 
 export CELERY_BEAT_NAME=celery-beat
 export CELERY_BEAT_REPLICAS=0

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.sh
@@ -69,7 +69,7 @@ export CELERY_WORKERS_CPU_REQUEST=500m
 export CELERY_WORKERS_MEMORY_LIMIT=4Gi
 export CELERY_WORKERS_MEMORY_REQUEST=2Gi
 export CELERY_WORKERS_CONCURRENCY=4
-export CELERY_WORKERS_QUEUES=mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,celery
+export CELERY_WORKERS_QUEUES=mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,mdn_api,celery
 
 export CELERY_BEAT_NAME=celery-beat
 export CELERY_BEAT_REPLICAS=0

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/prod.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/prod.sh
@@ -69,7 +69,7 @@ export CELERY_WORKERS_CPU_REQUEST=500m
 export CELERY_WORKERS_MEMORY_LIMIT=4Gi
 export CELERY_WORKERS_MEMORY_REQUEST=2Gi
 export CELERY_WORKERS_CONCURRENCY=4
-export CELERY_WORKERS_QUEUES=mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,celery
+export CELERY_WORKERS_QUEUES=mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,mdn_api,celery
 
 export CELERY_BEAT_NAME=celery-beat
 export CELERY_BEAT_REPLICAS=1

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/stage.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/stage.mm.sh
@@ -69,7 +69,7 @@ export CELERY_WORKERS_CPU_REQUEST=100m
 export CELERY_WORKERS_MEMORY_LIMIT=2Gi
 export CELERY_WORKERS_MEMORY_REQUEST=1Gi
 export CELERY_WORKERS_CONCURRENCY=4
-export CELERY_WORKERS_QUEUES=mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,celery
+export CELERY_WORKERS_QUEUES=mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,mdn_api,celery
 
 export CELERY_BEAT_NAME=celery-beat
 export CELERY_BEAT_REPLICAS=0

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
@@ -69,7 +69,7 @@ export CELERY_WORKERS_CPU_REQUEST=100m
 export CELERY_WORKERS_MEMORY_LIMIT=2Gi
 export CELERY_WORKERS_MEMORY_REQUEST=1Gi
 export CELERY_WORKERS_CONCURRENCY=4
-export CELERY_WORKERS_QUEUES=mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,celery
+export CELERY_WORKERS_QUEUES=mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,mdn_api,celery
 
 export CELERY_BEAT_NAME=celery-beat
 export CELERY_BEAT_REPLICAS=1


### PR DESCRIPTION
This PR simply adds the `mdn_api` Celery queue to the list of queues from which each Celery worker will pull tasks. The `mdn_api` Celery queue is added by https://github.com/mozilla/kuma/pull/5361.