### PR TITLE
update elb certs to reflect current state

### DIFF
--- a/apps/mdn/mdn-aws/k8s/regions/germany/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/germany/prod.mm.sh
@@ -29,7 +29,7 @@ export WEB_SERVICE_TYPE=LoadBalancer
 export WEB_SERVICE_PORT=443
 export WEB_SERVICE_TARGET_PORT=8000
 export WEB_SERVICE_PROTOCOL=TCP
-export WEB_SERVICE_CERT_ARN=arn:aws:acm:eu-central-1:178589013767:certificate/eb602c6b-4695-4c72-8a94-0e78c49b05b8
+export WEB_SERVICE_CERT_ARN=arn:aws:acm:eu-central-1:178589013767:certificate/fd5c782b-cf8a-421c-bb54-1fe699f8cc5d
 
 export API_SERVICE_NAME=api
 export API_SERVICE_TYPE=ClusterIP

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.sh
@@ -29,7 +29,7 @@ export WEB_SERVICE_TYPE=LoadBalancer
 export WEB_SERVICE_PORT=443
 export WEB_SERVICE_TARGET_PORT=8000
 export WEB_SERVICE_PROTOCOL=TCP
-export WEB_SERVICE_CERT_ARN=arn:aws:acm:us-west-2:178589013767:certificate/a03c16f6-988f-40f4-9c68-d8e00aa05023
+export WEB_SERVICE_CERT_ARN=arn:aws:acm:us-west-2:178589013767:certificate/6cd2746f-26e7-491f-95ba-4972b1aa5879
 
 export API_SERVICE_NAME=api
 export API_SERVICE_TYPE=ClusterIP

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/prod.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/prod.sh
@@ -29,7 +29,7 @@ export WEB_SERVICE_TYPE=LoadBalancer
 export WEB_SERVICE_PORT=443
 export WEB_SERVICE_TARGET_PORT=8000
 export WEB_SERVICE_PROTOCOL=TCP
-export WEB_SERVICE_CERT_ARN=arn:aws:acm:us-west-2:178589013767:certificate/a03c16f6-988f-40f4-9c68-d8e00aa05023
+export WEB_SERVICE_CERT_ARN=arn:aws:acm:us-west-2:178589013767:certificate/6cd2746f-26e7-491f-95ba-4972b1aa5879
 
 export API_SERVICE_NAME=api
 export API_SERVICE_TYPE=ClusterIP

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/stage.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/stage.mm.sh
@@ -29,7 +29,7 @@ export WEB_SERVICE_TYPE=LoadBalancer
 export WEB_SERVICE_PORT=443
 export WEB_SERVICE_TARGET_PORT=8000
 export WEB_SERVICE_PROTOCOL=TCP
-export WEB_SERVICE_CERT_ARN=arn:aws:acm:us-west-2:178589013767:certificate/971f12b3-01f7-4c2c-83e8-36a0731d60df
+export WEB_SERVICE_CERT_ARN=arn:aws:acm:us-west-2:178589013767:certificate/4c0418c7-6c02-4f23-89a9-f6e6709293d9
 
 export API_SERVICE_NAME=api
 export API_SERVICE_TYPE=ClusterIP

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
@@ -29,7 +29,7 @@ export WEB_SERVICE_TYPE=LoadBalancer
 export WEB_SERVICE_PORT=443
 export WEB_SERVICE_TARGET_PORT=8000
 export WEB_SERVICE_PROTOCOL=TCP
-export WEB_SERVICE_CERT_ARN=arn:aws:acm:us-west-2:178589013767:certificate/971f12b3-01f7-4c2c-83e8-36a0731d60df
+export WEB_SERVICE_CERT_ARN=arn:aws:acm:us-west-2:178589013767:certificate/4c0418c7-6c02-4f23-89a9-f6e6709293d9
 
 export API_SERVICE_NAME=api
 export API_SERVICE_TYPE=ClusterIP


### PR DESCRIPTION
I've created new SSL certs for the stage, prod, and standby ELB's, and updated each of the ELB's to use its new cert. The driver for this change is that we're going to route traffic for each of the `wiki.developer.allizom.org` and `wiki.developer.mozilla.org` domains directly to their respective ELB's. Those domains will only be used by users interested in creating/editing content, which is a very small (<100?) group, while the primary domains of `developer.allizom.org` and `developer.mozilla.org` (and temporarily the `beta.developer.allizom.org` and `beta.developer.mozilla.org` domains) will continue to go through the stage/prod CDN's.

This PR updates the `WEB_SERVICE_CERT_ARN` settings for stage, prod, and standby to reflect the current state as it exists in AWS.