### PR TITLE
Add IAM policy allowing mozilla-itsre fetching cloudwatch metrics

### DIFF
--- a/apps/mdn/mdn-aws/infra/main.tf
+++ b/apps/mdn/mdn-aws/infra/main.tf
@@ -204,3 +204,8 @@ module "mysql-eu-central-1-replica-prod" {
   instance_class      = "${lookup(var.rds, "instance_class.prod")}"
   monitoring_interval = "60"
 }
+
+module "metrics" {
+  source      = "./modules/metrics"
+}
+

--- a/apps/mdn/mdn-aws/infra/modules/metrics/main.tf
+++ b/apps/mdn/mdn-aws/infra/modules/metrics/main.tf
@@ -1,0 +1,32 @@
+# Allows mozilla-itsre account to consume Cloudwatch metrics
+
+resource "aws_iam_role" "cloudwatch_fetch_metrics" {
+  name               = "cloudwatch_fetch_metrics"
+  path               = "/itsre/"
+  assume_role_policy = "${data.aws_iam_policy_document.allow_fetch_cloudwatch_metrics.json}"
+}
+
+data "aws_iam_policy_document" "allow_fetch_cloudwatch_metrics" {
+  statement {
+    actions = [
+      "cloudwatch:Describe*",
+      "cloudwatch:GetMetricData",
+      "cloudwatch:GetMetricStatistics",
+      "cloudwatch:ListMetrics",
+    ]
+
+    effect    = "Allow"
+    resources = ["*"]
+  }
+
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::517826968395:root"]
+    }
+  }
+}
+

--- a/apps/mdn/mdn-aws/infra/modules/metrics/outputs.tf
+++ b/apps/mdn/mdn-aws/infra/modules/metrics/outputs.tf
@@ -1,0 +1,4 @@
+output "iam_role_arn" {
+  value       = "${aws_iam_role.cloudwatch_fetch_metrics.arn}"
+  description = "ARN of the user allowed to fetch metrics."
+}


### PR DESCRIPTION
I don't know whether this is the right place in the repo to put this IAM policy. Let me know what do you think and if you have a better place.