### PR TITLE
add MDN_API_CLOUDFRONT_DISTRIBUTIONID from secrets

### DIFF
--- a/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
@@ -116,6 +116,11 @@
               value: "{{ KUMA_MAINTENANCE_MODE }}"
             - name: MDN_API_S3_BUCKET_NAME
               value: "{{ KUMA_API_S3_BUCKET_NAME }}"
+            - name: MDN_API_CLOUDFRONT_DISTRIBUTIONID
+              valueFrom:
+                secretKeyRef:
+                  name: mdn-secrets
+                  key: aws-api-cloudfront-dist-id
             - name: MDN_CONTRIBUTION
               value: "{{ KUMA_ENABLE_CONTRIBUTIONS }}"
             - name: MDN_CONTRIBUTION_CONFIRMATION_EMAIL


### PR DESCRIPTION
Add `MDN_API_CLOUDFRONT_DISTRIBUTIONID` to the Kuma base deployment environment. This is a companion PR for mozilla/kuma#5472.