### PR TITLE
disable CSP enforcement on stage, report only

### DIFF
--- a/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
@@ -117,7 +117,7 @@ export KUMA_CELERY_TASK_ALWAYS_EAGER=False
 export KUMA_CELERY_WORKER_MAX_TASKS_PER_CHILD=0
 export KUMA_CSP_ENABLE_MIDDLEWARE=True
 export KUMA_CSP_REPORT_ENABLE=True
-export KUMA_CSP_REPORT_ONLY=False
+export KUMA_CSP_REPORT_ONLY=True
 export KUMA_CSP_REPORT_URI=https://sentry.prod.mozaws.net/api/72/security/?sentry_key=25e652a045b642dfaa310e92e800058a
 export KUMA_CSRF_COOKIE_SECURE=True
 export KUMA_DEBUG=False


### PR DESCRIPTION
This PR disables CSP enforcement on MDN stage, so CSP violations are only reported not enforced. The rationale for this was to avoid the confusion of things not working on stage due to CSP violations, but working on production (where CSP violations are not enforced nor reported). This is temporary until we can focus more on getting our CSP in order on MDN.