### PR TITLE
bug 1567187 - Unset STATIC_URL

### DIFF
--- a/apps/mdn/mdn-aws/k8s/regions/germany/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/germany/prod.mm.sh
@@ -134,7 +134,6 @@ export KUMA_PROTOCOL="https://"
 export KUMA_SECURE_HSTS_SECONDS=63072000
 export KUMA_SERVE_LEGACY=True
 export KUMA_SESSION_COOKIE_SECURE=True
-export KUMA_STATIC_URL=https://developer.mozilla.org/static/
 export KUMA_STRIPE_PUBLIC_KEY=pk_live_GZl4tCi8J5mWhKbJeRey4DSy
 export KUMA_WEB_CONCURRENCY=4
 

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.sh
@@ -134,7 +134,6 @@ export KUMA_PROTOCOL="https://"
 export KUMA_SECURE_HSTS_SECONDS=63072000
 export KUMA_SERVE_LEGACY=True
 export KUMA_SESSION_COOKIE_SECURE=True
-export KUMA_STATIC_URL=https://developer.mozilla.org/static/
 export KUMA_STRIPE_PUBLIC_KEY=pk_live_GZl4tCi8J5mWhKbJeRey4DSy
 export KUMA_WEB_CONCURRENCY=4
 

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/prod.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/prod.sh
@@ -134,7 +134,6 @@ export KUMA_PROTOCOL="https://"
 export KUMA_SECURE_HSTS_SECONDS=63072000
 export KUMA_SERVE_LEGACY=True
 export KUMA_SESSION_COOKIE_SECURE=True
-export KUMA_STATIC_URL=https://developer.mozilla.org/static/
 export KUMA_STRIPE_PRODUCT_ID=prod_monthly
 export KUMA_STRIPE_PUBLIC_KEY=pk_live_GZl4tCi8J5mWhKbJeRey4DSy
 export KUMA_WEB_CONCURRENCY=4

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/stage.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/stage.mm.sh
@@ -134,7 +134,6 @@ export KUMA_PROTOCOL="https://"
 export KUMA_SECURE_HSTS_SECONDS=63072000
 export KUMA_SERVE_LEGACY=True
 export KUMA_SESSION_COOKIE_SECURE=True
-export KUMA_STATIC_URL=https://developer.allizom.org/static/
 export KUMA_STRIPE_PUBLIC_KEY=pk_test_8QPCGoZzaushrXveHRqHAZch
 export KUMA_WEB_CONCURRENCY=4
 

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
@@ -138,7 +138,6 @@ export KUMA_PROTOCOL="https://"
 export KUMA_SECURE_HSTS_SECONDS=63072000
 export KUMA_SERVE_LEGACY=True
 export KUMA_SESSION_COOKIE_SECURE=True
-export KUMA_STATIC_URL=https://developer.allizom.org/static/
 export KUMA_STRIPE_PRODUCT_ID=prod_test
 export KUMA_STRIPE_PUBLIC_KEY=pk_test_8QPCGoZzaushrXveHRqHAZch
 export KUMA_WEB_CONCURRENCY=4


### PR DESCRIPTION
I have to admit, I rushed this one. I just looked for places where it was set using `ripgrep` and editted them quickly. I don't even know how this stuff works or what other crazy repercussions there are. 

Either way, I'm pretty confident the [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1567187) is right. 
Not sure what it means for stage though. 