### PR TITLE
ensure all requests to api service are wiki requests

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -138,6 +138,7 @@ export KUMA_STATIC_URL ?= /static/
 export KUMA_STRIPE_PRODUCT_ID ?= ""
 export KUMA_STRIPE_PUBLIC_KEY ?= ""
 export KUMA_WEB_CONCURRENCY ?= 4
+export KUMA_WIKI_HOST ?= wiki.${KUMA_DOMAIN}
 
 export INTERACTIVE_EXAMPLES_BASE_URL ?= https://interactive-examples.mdn.mozilla.net
 
@@ -548,6 +549,7 @@ k8s-api:
 		KUMA_MEMORY_REQUEST=${API_MEMORY_REQUEST} \
 		KUMA_ALLOWED_HOSTS=${API_ALLOWED_HOSTS} \
 		KUMA_RATELIMIT_ENABLE=False \
+		KUMA_WIKI_HOST=${API_SERVICE_NAME} \
 		NEW_RELIC_APP_NAME=${NEW_RELIC_API_NAME} \
 		j2 kuma.deploy.yaml.j2 | ${KUBECTL} apply -n ${K8S_NAMESPACE} -f -
 

--- a/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
@@ -195,6 +195,8 @@
                 secretKeyRef:
                   name: mdn-secrets
                   key: stripe-secret-key
+            - name: WIKI_HOST
+              value: {{ KUMA_WIKI_HOST }}
             # Other environment overrides
             - name: PYTHONUNBUFFERED
               value: "True"


### PR DESCRIPTION
This PR ensures that all requests made to the `api` service in k8s are always handled as `wiki` requests, since the `wiki` domain directly supports the full range of `$` endpoints like `$history`. Without this change, requests from `kumascript` macros to the `$history` or `$revision` endpoints of the `api` service would be redirected to the `wiki` domain. This PR is a companion to mozilla/kuma#5639.