### PR TITLE
Rename input argument for hosted_zone module

### DIFF
--- a/dns/hosted_zone/inputs.tf
+++ b/dns/hosted_zone/inputs.tf
@@ -1,5 +1,5 @@
-variable region {}
+variable "domain_name" {}
 
-variable domain_name {}
+variable "zone_id" {}
 
-variable zone_id {}
+variable "zone_name" {}

--- a/dns/hosted_zone/main.tf
+++ b/dns/hosted_zone/main.tf
@@ -1,26 +1,25 @@
 resource aws_route53_zone "region-zone" {
-  name = "${var.region}.${var.domain_name}"
+  name = "${var.zone_name}.${var.domain_name}"
 
   lifecycle {
     create_before_destroy = true
   }
 
   tags {
-    Name    = "${var.region}.${var.domain_name}"
-    Purpose = "Region stub zone"
-    Region  = "${var.region}"
+    Name      = "${var.zone_name}.${var.domain_name}"
+    Purpose   = "${var.zone_name} stub zone"
+    Terraform = "true"
   }
 }
 
 resource aws_route53_record "region-hosted-record" {
   zone_id = "${var.zone_id}"
-  name    = "${var.region}"
+  name    = "${var.zone_name}"
 
-  type  = "NS"
-  ttl   = "86400"
+  type = "NS"
+  ttl  = "86400"
 
   records = [
-    "${aws_route53_zone.region-zone.name_servers}"
+    "${aws_route53_zone.region-zone.name_servers}",
   ]
-
 }

--- a/dns/main.tf
+++ b/dns/main.tf
@@ -40,23 +40,32 @@ resource aws_route53_zone "mdn-dev" {
   }
 }
 
+# Hosted zone for mozit.cloud domains
+# everything not mozit.cloud doesn't go here
 module "us-west-2" {
   source      = "./hosted_zone"
-  region      = "us-west-2"
+  zone_name   = "us-west-2"
   domain_name = "${var.domain_name}"
   zone_id     = "${aws_route53_zone.master-zone.id}"
 }
 
 module "eu-central-1" {
   source      = "./hosted_zone"
-  region      = "eu-central-1"
+  zone_name   = "eu-central-1"
   domain_name = "${var.domain_name}"
   zone_id     = "${aws_route53_zone.master-zone.id}"
 }
 
 module "us-west-2a" {
   source      = "./hosted_zone"
-  region      = "us-west-2a"
+  zone_name   = "us-west-2a"
+  domain_name = "${var.domain_name}"
+  zone_id     = "${aws_route53_zone.master-zone.id}"
+}
+
+module "stage" {
+  source      = "./hosted_zone"
+  zone_name   = "stage"
   domain_name = "${var.domain_name}"
   zone_id     = "${aws_route53_zone.master-zone.id}"
 }

--- a/dns/outputs.tf
+++ b/dns/outputs.tf
@@ -25,3 +25,7 @@ output "us-west-2a-zone-id" {
 output "eu-central-1-zone-id" {
   value = "${module.eu-central-1.hosted_zone_id}"
 }
+
+output "stage-zone-id" {
+  value = "${module.stage.hosted_zone_id}"
+}


### PR DESCRIPTION
Rename one of the input variables to `zone_name` now this module can be used as a generic zone creation module.

Sneaked in a few formatting change as well