### PR TITLE
set the sentry env variables for the ssr deployment

### DIFF
--- a/apps/mdn/mdn-aws/k8s/ssr.deploy.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/ssr.deploy.yaml.j2
@@ -44,6 +44,13 @@ spec:
                   key: NEW_RELIC_LICENSE_KEY
             - name: NODE_ENV
               value: "production"
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: mdn-secrets
+                  key: sentry-dsn
+            - name: SENTRY_ENVIRONMENT
+              value: "{{ K8S_CLUSTER_SHORT_NAME }}:{{ TARGET_ENVIRONMENT }}"
             - name: SSR_PORT
               value: "{{ SSR_CONTAINER_PORT }}"
           resources:


### PR DESCRIPTION
Configure the environment of the `ssr` deployment with the key/value pairs needed by Sentry.