### PR TITLE
Update k8s ec2 instance to m5 class

### DIFF
--- a/k8s/clusters/us-west-2a/out/terraform/data/aws_iam_role_policy_masters.k8s.us-west-2a.mdn.mozit.cloud_policy
+++ b/k8s/clusters/us-west-2a/out/terraform/data/aws_iam_role_policy_masters.k8s.us-west-2a.mdn.mozit.cloud_policy
@@ -55,8 +55,7 @@
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
-        "autoscaling:DescribeTags",
-        "ec2:DescribeLaunchTemplateVersions"
+        "autoscaling:DescribeTags"
       ],
       "Resource": [
         "*"

--- a/k8s/clusters/us-west-2a/out/terraform/data/aws_launch_configuration_master-us-west-2a.masters.k8s.us-west-2a.mdn.mozit.cloud_user_data
+++ b/k8s/clusters/us-west-2a/out/terraform/data/aws_launch_configuration_master-us-west-2a.masters.k8s.us-west-2a.mdn.mozit.cloud_user_data
@@ -17,8 +17,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-NODEUP_URL=https://kubeupv2.s3.amazonaws.com/kops/1.12.2/linux/amd64/nodeup
-NODEUP_HASH=e7e49d1fff61badc2fff402e80858d081aa88a26
+NODEUP_URL=https://kubeupv2.s3.amazonaws.com/kops/1.11.1/linux/amd64/nodeup
+NODEUP_HASH=d4119d57e89b0a2b6c1200178d9efa890cf2f6b2
 
 export AWS_REGION=us-west-2
 
@@ -276,8 +276,8 @@ cat > kube_env.yaml << '__EOF_KUBE_ENV'
 Assets:
 - be55c02936004fb54487e65a18650d9ec17585cb@https://storage.googleapis.com/kubernetes-release/release/v1.11.7/bin/linux/amd64/kubelet
 - 142b72418855b985b8a89e81f17df9d5fb88f1a9@https://storage.googleapis.com/kubernetes-release/release/v1.11.7/bin/linux/amd64/kubectl
-- 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-- 97bc9bbdf1bef1339311e7a4cb26a88b3e75e138@https://github.com/kubernetes/kops/releases/download/1.12.2/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.12.2/linux/amd64/utils.tar.gz
+- d595d3ded6499a64e8dac02466e2f5f2ce257c9f@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.6.0.tgz
+- b8fef14d3b0594d4c02d6bf94c4fe7329fb7da73@https://kubeupv2.s3.amazonaws.com/kops/1.11.1/linux/amd64/utils.tar.gz
 ClusterName: k8s.us-west-2a.mdn.mozit.cloud
 ConfigBase: s3://kops-state-4e366a3ac64d1b4022c8b5e35efbd288/k8s.us-west-2a.mdn.mozit.cloud
 InstanceGroupName: master-us-west-2a
@@ -287,11 +287,9 @@ Tags:
 channels:
 - s3://kops-state-4e366a3ac64d1b4022c8b5e35efbd288/k8s.us-west-2a.mdn.mozit.cloud/addons/bootstrap-channel.yaml
 protokubeImage:
-  hash: ecbe565877e88f3e75d7cad24855994e37892f26
-  name: protokube:1.12.2
-  sources:
-  - https://github.com/kubernetes/kops/releases/download/1.12.2/images-protokube.tar.gz
-  - https://kubeupv2.s3.amazonaws.com/kops/1.12.2/images/protokube.tar.gz
+  hash: 93cc7561bc965e9c754312ed660d6c209586c7a6
+  name: protokube:1.11.1
+  source: https://kubeupv2.s3.amazonaws.com/kops/1.11.1/images/protokube.tar.gz
 
 __EOF_KUBE_ENV
 

--- a/k8s/clusters/us-west-2a/out/terraform/data/aws_launch_configuration_nodes.k8s.us-west-2a.mdn.mozit.cloud_user_data
+++ b/k8s/clusters/us-west-2a/out/terraform/data/aws_launch_configuration_nodes.k8s.us-west-2a.mdn.mozit.cloud_user_data
@@ -17,8 +17,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-NODEUP_URL=https://kubeupv2.s3.amazonaws.com/kops/1.12.2/linux/amd64/nodeup
-NODEUP_HASH=e7e49d1fff61badc2fff402e80858d081aa88a26
+NODEUP_URL=https://kubeupv2.s3.amazonaws.com/kops/1.11.1/linux/amd64/nodeup
+NODEUP_HASH=d4119d57e89b0a2b6c1200178d9efa890cf2f6b2
 
 export AWS_REGION=us-west-2
 
@@ -190,8 +190,8 @@ cat > kube_env.yaml << '__EOF_KUBE_ENV'
 Assets:
 - be55c02936004fb54487e65a18650d9ec17585cb@https://storage.googleapis.com/kubernetes-release/release/v1.11.7/bin/linux/amd64/kubelet
 - 142b72418855b985b8a89e81f17df9d5fb88f1a9@https://storage.googleapis.com/kubernetes-release/release/v1.11.7/bin/linux/amd64/kubectl
-- 52e9d2de8a5f927307d9397308735658ee44ab8d@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz
-- 97bc9bbdf1bef1339311e7a4cb26a88b3e75e138@https://github.com/kubernetes/kops/releases/download/1.12.2/linux-amd64-utils.tar.gz,https://kubeupv2.s3.amazonaws.com/kops/1.12.2/linux/amd64/utils.tar.gz
+- d595d3ded6499a64e8dac02466e2f5f2ce257c9f@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.6.0.tgz
+- b8fef14d3b0594d4c02d6bf94c4fe7329fb7da73@https://kubeupv2.s3.amazonaws.com/kops/1.11.1/linux/amd64/utils.tar.gz
 ClusterName: k8s.us-west-2a.mdn.mozit.cloud
 ConfigBase: s3://kops-state-4e366a3ac64d1b4022c8b5e35efbd288/k8s.us-west-2a.mdn.mozit.cloud
 InstanceGroupName: nodes
@@ -201,11 +201,9 @@ Tags:
 channels:
 - s3://kops-state-4e366a3ac64d1b4022c8b5e35efbd288/k8s.us-west-2a.mdn.mozit.cloud/addons/bootstrap-channel.yaml
 protokubeImage:
-  hash: ecbe565877e88f3e75d7cad24855994e37892f26
-  name: protokube:1.12.2
-  sources:
-  - https://github.com/kubernetes/kops/releases/download/1.12.2/images-protokube.tar.gz
-  - https://kubeupv2.s3.amazonaws.com/kops/1.12.2/images/protokube.tar.gz
+  hash: 93cc7561bc965e9c754312ed660d6c209586c7a6
+  name: protokube:1.11.1
+  source: https://kubeupv2.s3.amazonaws.com/kops/1.11.1/images/protokube.tar.gz
 
 __EOF_KUBE_ENV
 

--- a/k8s/clusters/us-west-2a/out/terraform/kubernetes.tf
+++ b/k8s/clusters/us-west-2a/out/terraform/kubernetes.tf
@@ -224,8 +224,8 @@ resource "aws_key_pair" "kubernetes-k8s-us-west-2a-mdn-mozit-cloud-44ff04d0bf893
 
 resource "aws_launch_configuration" "master-us-west-2a-masters-k8s-us-west-2a-mdn-mozit-cloud" {
   name_prefix                 = "master-us-west-2a.masters.k8s.us-west-2a.mdn.mozit.cloud-"
-  image_id                    = "ami-4bfe6f33"
-  instance_type               = "m4.large"
+  image_id                    = "ami-0f1ed9114ee01d145"
+  instance_type               = "m5.large"
   key_name                    = "${aws_key_pair.kubernetes-k8s-us-west-2a-mdn-mozit-cloud-44ff04d0bf8934c5c30d253bd7df3bef.id}"
   iam_instance_profile        = "${aws_iam_instance_profile.masters-k8s-us-west-2a-mdn-mozit-cloud.id}"
   security_groups             = ["${aws_security_group.masters-k8s-us-west-2a-mdn-mozit-cloud.id}"]
@@ -247,8 +247,8 @@ resource "aws_launch_configuration" "master-us-west-2a-masters-k8s-us-west-2a-md
 
 resource "aws_launch_configuration" "nodes-k8s-us-west-2a-mdn-mozit-cloud" {
   name_prefix                 = "nodes.k8s.us-west-2a.mdn.mozit.cloud-"
-  image_id                    = "ami-4bfe6f33"
-  instance_type               = "m4.xlarge"
+  image_id                    = "ami-0f1ed9114ee01d145"
+  instance_type               = "m5.xlarge"
   key_name                    = "${aws_key_pair.kubernetes-k8s-us-west-2a-mdn-mozit-cloud-44ff04d0bf8934c5c30d253bd7df3bef.id}"
   iam_instance_profile        = "${aws_iam_instance_profile.nodes-k8s-us-west-2a-mdn-mozit-cloud.id}"
   security_groups             = ["${aws_security_group.nodes-k8s-us-west-2a-mdn-mozit-cloud.id}"]


### PR DESCRIPTION
Updates kubernetes cluster to to the newer m5 instance class. Fixes #296 