### PR TITLE
Updating permission to allow the app to invalidate the cdn cache

### DIFF
--- a/apps/mdn/developer-portal/main.tf
+++ b/apps/mdn/developer-portal/main.tf
@@ -19,6 +19,7 @@ module "bucket_stage" {
   create_user         = true
   bucket_name         = "developer-portal"
   eks_worker_role_arn = "${data.terraform_remote_state.eks-us-west-2.developer_portal_worker_iam_role_arn}"
+  distribution_id     = "${module.cdn_stage.cloudfront_id}"
 }
 
 module "efs_stage" {

--- a/apps/mdn/developer-portal/modules/bucket/main.tf
+++ b/apps/mdn/developer-portal/modules/bucket/main.tf
@@ -127,25 +127,6 @@ data "aws_iam_policy_document" "bucket_public_policy" {
 
 data "aws_iam_policy_document" "media_bucket_public_policy" {
   statement {
-    sid    = "AllowListBucket"
-    effect = "Allow"
-
-    actions = [
-      "s3:ListBucket",
-    ]
-
-    principals {
-      type        = "*"
-      identifiers = ["*"]
-    }
-
-    resources = [
-      "arn:aws:s3:::${local.media_bucket}",
-    ]
-  }
-
-  statement {
-    sid    = "AllowIndexHTML"
     effect = "Allow"
 
     actions = [
@@ -228,6 +209,21 @@ data "aws_iam_policy_document" "bucket_policy" {
     resources = [
       "arn:aws:s3:::${local.bucket_name}/*",
       "arn:aws:s3:::${local.media_bucket}/*",
+    ]
+  }
+
+  statement {
+    sid    = "AllowCDNInvalidate"
+    effect = "Allow"
+
+    actions = [
+      "cloudfront:CreateInvalidation",
+      "cloudfront:GetInvalidation",
+      "cloudfront:ListInvalidation",
+    ]
+
+    resources = [
+      "arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:distribution/${var.distribution_id}",
     ]
   }
 }

--- a/apps/mdn/developer-portal/modules/bucket/variables.tf
+++ b/apps/mdn/developer-portal/modules/bucket/variables.tf
@@ -15,3 +15,5 @@ variable "create_user" {
 variable "bucket_acl" {
   default = "public-read"
 }
+
+variable "distribution_id" {}


### PR DESCRIPTION
This in conjunction with this PR https://github.com/mdn/developer-portal/pull/358 will allow CDN invalidation request to happen via the developer-portal app