### PR TITLE
Roll our own block-aws cron image

### DIFF
--- a/k8s/install/services/block-aws/block-aws-cron.yaml
+++ b/k8s/install/services/block-aws/block-aws-cron.yaml
@@ -45,7 +45,7 @@ spec:
         spec:
           containers:
           - name: block-aws-cron
-            image: quay.io/mozmar/blockaws:673f9b0
+            image: mdnwebdocs/blockaws:611e8fe
             env:
               - name: DMS_URL
                 valueFrom:

--- a/k8s/tools/block-aws/Dockerfile
+++ b/k8s/tools/block-aws/Dockerfile
@@ -22,7 +22,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Install kubectl
 # to get latest version: "curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt"
-ENV KUBECTL_VERSION="v1.10.1"
+ENV KUBECTL_VERSION="v1.11.7"
 ADD https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl /usr/local/bin/kubectl
 RUN chmod +x /usr/local/bin/kubectl
 

--- a/k8s/tools/block-aws/build.sh
+++ b/k8s/tools/block-aws/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-docker build . -t quay.io/mozmar/blockaws:${GIT_COMMIT:=$(git rev-parse --short HEAD)}
-docker push quay.io/mozmar/blockaws:${GIT_COMMIT}
+docker build . -t mdnwebdocs/blockaws:${GIT_COMMIT:=$(git rev-parse --short HEAD)}
+docker push mdnwebdocs/blockaws:${GIT_COMMIT}


### PR DESCRIPTION
This replaces the dependence on mozmeao's docker image. We will roll our own image from now on