### PR TITLE
fix DB migration job for use with Python 2 or 3

### DIFF
--- a/apps/mdn/mdn-aws/k8s/mdn-db-migration-job.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/mdn-db-migration-job.yaml.j2
@@ -10,7 +10,7 @@ spec:
       restartPolicy: Never
 {% include 'kuma.base.yaml.j2' %}
           command:
-            - python2.7
+            - python
           args:
             - manage.py
             - migrate


### PR DESCRIPTION
This PR fixes the DB migration job so that it can be used by both Python 2 and Python 3.