### PR TITLE
use default celery logfile setting for python 3

### DIFF
--- a/apps/mdn/mdn-aws/k8s/celery.beat.deploy.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/celery.beat.deploy.yaml.j2
@@ -5,4 +5,3 @@
             - "--app=kuma.celery:app"
             - "beat"
             - "--loglevel=INFO"
-            - "--logfile=/dev/stdout"

--- a/apps/mdn/mdn-aws/k8s/celery.workers.deploy.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/celery.workers.deploy.yaml.j2
@@ -7,6 +7,5 @@
             - "--app=kuma.celery:app"
             - worker
             - "--loglevel=INFO"
-            - "--logfile=/dev/stdout"
             - "--concurrency={{ CELERY_WORKERS_CONCURRENCY }}"
             - "--queues={{ CELERY_WORKERS_QUEUES }}"


### PR DESCRIPTION
Fixes https://github.com/mdn/kuma/issues/6097

@callahad deserves the credit for discovering this fix. I deployed this PR to stage and confirmed that it fixes https://github.com/mdn/kuma/issues/6097.

There was a concern that by logging to `stderr` on the Celery workers and the Celery `beat` worker, our Papertrail instance wouldn't receive the `stderr` stream, but I confirmed that Papertrail still receives the log information even though it's source is `stderr`.