### PR TITLE
Add bucket and cdn logging for developer-portal

### DIFF
--- a/apps/mdn/developer-portal/main.tf
+++ b/apps/mdn/developer-portal/main.tf
@@ -46,6 +46,7 @@ module "cdn_stage" {
   environment     = "stage"
   cdn_aliases     = ["developer-portal-stage.mdn.mozit.cloud", "developer-portal.stage.mdn.mozit.cloud", "developer-portal-published.stage.mdn.mozit.cloud"]
   origin_bucket   = "${module.bucket_stage.bucket_id}"
+  logging_bucket  = "${module.bucket_stage.logging_bucket_id}"
   certificate_arn = "${data.aws_acm_certificate.developer-portal-cdn-stage.arn}"
 }
 
@@ -90,6 +91,7 @@ module "cdn_prod" {
   environment     = "prod"
   cdn_aliases     = ["developer-portal.prod.mdn.mozit.cloud", "developer-portal-published.prod.mdn.mozit.cloud", "developer.mozilla.com"]
   origin_bucket   = "${module.bucket_prod.bucket_id}"
+  logging_bucket  = "${module.bucket_prod.logging_bucket_id}"
   certificate_arn = "${data.aws_acm_certificate.developer-portal-cdn-prod.arn}"
 }
 

--- a/apps/mdn/developer-portal/modules/bucket/main.tf
+++ b/apps/mdn/developer-portal/modules/bucket/main.tf
@@ -4,6 +4,7 @@ locals {
   # All other things reference this
   identifier   = "${var.bucket_name}-${var.environment}"
   media_bucket = "${var.bucket_name}-${var.environment}-media-${data.aws_caller_identity.current.account_id}"
+  log_bucket   = "${var.bucket_name}-${var.environment}-logs-${data.aws_caller_identity.current.account_id}"
   attachments  = "devportal-media-${var.environment}"
 }
 
@@ -22,6 +23,11 @@ resource "aws_s3_bucket" "this" {
   website {
     index_document = "index.html"
     error_document = "404.html"
+  }
+
+  logging {
+    target_bucket = "${aws_s3_bucket.logging.id}"
+    target_prefix = "bucket/"
   }
 
   tags {
@@ -46,7 +52,20 @@ resource "aws_s3_bucket" "attachments" {
   }
 
   tags {
-    name        = "${local.attachments}"
+    Name        = "${local.attachments}"
+    Region      = "${var.region}"
+    Environment = "${var.environment}"
+    Project     = "developer-portal"
+    Terraform   = "true"
+  }
+}
+
+resource "aws_s3_bucket" "logging" {
+  bucket = "${local.log_bucket}"
+  acl    = "log-delivery-write"
+
+  tags {
+    Name        = "${local.log_bucket}"
     Region      = "${var.region}"
     Environment = "${var.environment}"
     Project     = "developer-portal"

--- a/apps/mdn/developer-portal/modules/bucket/outputs.tf
+++ b/apps/mdn/developer-portal/modules/bucket/outputs.tf
@@ -37,3 +37,11 @@ output "media_bucket_id" {
 output "media_bucket_domain_name" {
   value = "${element(concat(aws_s3_bucket.attachments.*.bucket_domain_name, list("")),0)}"
 }
+
+output "logging_bucket_id" {
+  value = "${element(concat(aws_s3_bucket.logging.*.id, list("")),0)}"
+}
+
+output "logging_bucket_domain_name" {
+  value = "${element(concat(aws_s3_bucket.logging.*.bucket_domain_name, list("")),0)}"
+}

--- a/apps/mdn/developer-portal/modules/cdn/main.tf
+++ b/apps/mdn/developer-portal/modules/cdn/main.tf
@@ -4,6 +4,10 @@ data "aws_s3_bucket" "selected" {
   bucket = "${var.origin_bucket}"
 }
 
+data "aws_s3_bucket" "logging" {
+  bucket = "${var.logging_bucket}"
+}
+
 locals {
   servicename = "${var.servicename}-${var.environment}"
 }
@@ -13,6 +17,12 @@ resource "aws_cloudfront_distribution" "this" {
   comment             = "developer-portal ${var.environment} CDN"
   default_root_object = "index.html"
   aliases             = "${var.cdn_aliases}"
+
+  logging_config {
+    include_cookies = false
+    bucket          = "${data.aws_s3_bucket.logging.bucket_domain_name}"
+    prefix          = "cdn/"
+  }
 
   custom_error_response {
     error_code            = "404"

--- a/apps/mdn/developer-portal/modules/cdn/variables.tf
+++ b/apps/mdn/developer-portal/modules/cdn/variables.tf
@@ -18,6 +18,8 @@ variable "cdn_aliases" {
 
 variable "origin_bucket" {}
 
+variable "logging_bucket" {}
+
 variable "certificate_arn" {}
 
 variable "cloudfront_protocol_policy" {


### PR DESCRIPTION
This adds logging for the s3 bucket and CDN for developer portal

Resolves https://github.com/mdn/developer-portal/issues/675