### PR TITLE
add behavior for static files to attachments cdn

### DIFF
--- a/apps/mdn/mdn-aws/infra/modules/mdn-cdn/cloudfront_attachments/main.tf
+++ b/apps/mdn/mdn-aws/infra/modules/mdn-cdn/cloudfront_attachments/main.tf
@@ -65,6 +65,29 @@ resource "aws_cloudfront_distribution" "mdn-attachments-cf-dist" {
     error_code            = 404
   }
 
+  # 0
+  ordered_cache_behavior {
+    path_pattern = "static/*"
+
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    min_ttl                = 0
+    smooth_streaming       = false
+    target_origin_id       = "${var.distribution_name}"
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
   default_cache_behavior {
     allowed_methods = ["GET", "HEAD", "OPTIONS"]
     cached_methods  = ["GET", "HEAD", "OPTIONS"]


### PR DESCRIPTION
This PR is a companion to https://github.com/mdn/kuma/pull/6176 (see https://github.com/mdn/kuma/issues/6115 for additional context).

When https://github.com/mdn/kuma/pull/6176 is deployed, static files will also be served through the prod attachments CDN (there is no stage attachments CDN). We need to ensure that those static files will be cached according to their cache-control headers (which specify a maximum cache time since the files are hashed) via a special `static/*` behavior instead of using the default behavior which caches for only 24 hours.

I've already manually created the special `static/*` behavior on the prod attachments CDN, so there's no need to merge this before https://github.com/mdn/kuma/pull/6176 is deployed. This PR simply makes sure that change is reflected in our Terraform.

