### PR TITLE
Optimize cdn configuration for some MDN websites

### DIFF
--- a/apps/mdn/insights/modules/cdn/main.tf
+++ b/apps/mdn/insights/modules/cdn/main.tf
@@ -131,9 +131,10 @@ resource "aws_cloudfront_distribution" "site-distribution" {
     }
 
     viewer_protocol_policy = "${var.cloudfront_protocol_policy}"
+    compress               = true
+    default_ttl            = 3600
     min_ttl                = 0
-    default_ttl            = 600
-    max_ttl                = 600
+    max_ttl                = 86400
   }
 
   restrictions {

--- a/apps/mdn/mdn-dev/main.tf
+++ b/apps/mdn/mdn-dev/main.tf
@@ -1,5 +1,6 @@
 provider "aws" {
-  region = "${var.region}"
+  version = "~> 2"
+  region  = "${var.region}"
 }
 
 provider "aws" {


### PR DESCRIPTION
Optimizing configuration for some of the MDN CDN's. Most of these sites are static sites so we can extend the TTL of the CDN as well as enable compression.