### PR TITLE
enable multi-auth (Google login) on stage

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -134,6 +134,7 @@ export KUMA_LEGACY_ROOT ?= /mdn/www
 export KUMA_MAINTENANCE_MODE ?= False
 export KUMA_MEDIA_ROOT ?= /mdn/www
 export KUMA_MEDIA_URL ?= /media/
+export KUMA_MULTI_AUTH_ENABLED ?= False
 export KUMA_PROTOCOL ?= "https://"
 export KUMA_SECURE_HSTS_SECONDS ?= 0
 export KUMA_SERVE_LEGACY ?= True

--- a/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/kuma.base.yaml.j2
@@ -150,6 +150,8 @@
               value: {{ KUMA_MEDIA_ROOT }}
             - name: MEDIA_URL
               value: {{ KUMA_MEDIA_URL }}
+            - name: MULTI_AUTH_ENABLED
+              value: "{{ KUMA_MULTI_AUTH_ENABLED }}"
             - name: NEW_RELIC_APP_NAME
               value: {{ NEW_RELIC_APP_NAME }}
             - name: NEW_RELIC_BROWSER_MONITOR_ENABLE

--- a/apps/mdn/mdn-aws/k8s/regions/germany/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/germany/prod.mm.sh
@@ -138,6 +138,7 @@ export KUMA_LEGACY_ROOT=/mdn/www
 export KUMA_MAINTENANCE_MODE=True
 export KUMA_MEDIA_ROOT=/mdn/www
 export KUMA_MEDIA_URL=https://developer.mozilla.org/media/
+export KUMA_MULTI_AUTH_ENABLED=False
 export KUMA_PROTOCOL="https://"
 export KUMA_SECURE_HSTS_SECONDS=63072000
 export KUMA_SERVE_LEGACY=True

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.sh
@@ -138,6 +138,7 @@ export KUMA_LEGACY_ROOT=/mdn/www
 export KUMA_MAINTENANCE_MODE=True
 export KUMA_MEDIA_ROOT=/mdn/www
 export KUMA_MEDIA_URL=https://developer.mozilla.org/media/
+export KUMA_MULTI_AUTH_ENABLED=False
 export KUMA_PROTOCOL="https://"
 export KUMA_SECURE_HSTS_SECONDS=63072000
 export KUMA_SERVE_LEGACY=True

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/prod.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/prod.sh
@@ -138,6 +138,7 @@ export KUMA_LEGACY_ROOT=/mdn/www
 export KUMA_MAINTENANCE_MODE=False
 export KUMA_MEDIA_ROOT=/mdn/www
 export KUMA_MEDIA_URL=https://developer.mozilla.org/media/
+export KUMA_MULTI_AUTH_ENABLED=False
 export KUMA_PROTOCOL="https://"
 export KUMA_SECURE_HSTS_SECONDS=63072000
 export KUMA_SERVE_LEGACY=True

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/stage.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/stage.mm.sh
@@ -138,6 +138,7 @@ export KUMA_LEGACY_ROOT=/mdn/www
 export KUMA_MAINTENANCE_MODE=True
 export KUMA_MEDIA_ROOT=/mdn/www
 export KUMA_MEDIA_URL=https://developer.allizom.org/media/
+export KUMA_MULTI_AUTH_ENABLED=True
 export KUMA_PROTOCOL="https://"
 export KUMA_SECURE_HSTS_SECONDS=63072000
 export KUMA_SERVE_LEGACY=True

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
@@ -138,6 +138,7 @@ export KUMA_LEGACY_ROOT=/mdn/www
 export KUMA_MAINTENANCE_MODE=False
 export KUMA_MEDIA_ROOT=/mdn/www
 export KUMA_MEDIA_URL=https://developer.allizom.org/media/
+export KUMA_MULTI_AUTH_ENABLED=True
 export KUMA_PROTOCOL="https://"
 export KUMA_SECURE_HSTS_SECONDS=63072000
 export KUMA_SERVE_LEGACY=True


### PR DESCRIPTION
This PR enables multi-auth (Google sign-ups/logins) on stage, and keeps it disabled (for now) on production.