### PR TITLE
Update code to terraform 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 
 env:
   global:
-    - TERRAFORM_VERSION="0.11.14"
+    - TERRAFORM_VERSION="0.12.21"
     - IMAGE="hashicorp/terraform"
 
 before_install:

--- a/apps/mdn/insights/modules/bucket/main.tf
+++ b/apps/mdn/insights/modules/bucket/main.tf
@@ -1,10 +1,10 @@
 resource "aws_s3_bucket" "this" {
-  bucket = "${var.bucket_name}"
+  bucket = var.bucket_name
   acl    = "public-read"
-  policy = "${data.aws_iam_policy_document.bucket_policy.json}"
+  policy = data.aws_iam_policy_document.bucket_policy.json
 
-  tags {
-    Name      = "${var.bucket_name}"
+  tags = {
+    Name      = var.bucket_name
     Project   = "insights"
     Terraform = "true"
   }
@@ -28,3 +28,4 @@ data "aws_iam_policy_document" "bucket_policy" {
     ]
   }
 }
+

--- a/apps/mdn/insights/modules/bucket/outputs.tf
+++ b/apps/mdn/insights/modules/bucket/outputs.tf
@@ -1,11 +1,12 @@
 output "bucket_id" {
-  value = "${aws_s3_bucket.this.id}"
+  value = aws_s3_bucket.this.id
 }
 
 output "bucket_domain_name" {
-  value = "${aws_s3_bucket.this.bucket_domain_name}"
+  value = aws_s3_bucket.this.bucket_domain_name
 }
 
 output "bucket_regional_domain_name" {
-  value = "${aws_s3_bucket.this.bucket_regional_domain_name}"
+  value = aws_s3_bucket.this.bucket_regional_domain_name
 }
+

--- a/apps/mdn/insights/modules/bucket/variables.tf
+++ b/apps/mdn/insights/modules/bucket/variables.tf
@@ -5,3 +5,4 @@ variable "region" {
 variable "bucket_name" {
   default = "mdn-web-dna"
 }
+

--- a/apps/mdn/insights/modules/cdn/outputs.tf
+++ b/apps/mdn/insights/modules/cdn/outputs.tf
@@ -1,15 +1,16 @@
 output "site_bucket" {
-  value = "${aws_s3_bucket.site-bucket.id}"
+  value = aws_s3_bucket.site-bucket.id
 }
 
 output "cloudfront_id" {
-  value = "${aws_cloudfront_distribution.site-distribution.id}"
+  value = aws_cloudfront_distribution.site-distribution.id
 }
 
 output "cloudfront_domain" {
-  value = "${aws_cloudfront_distribution.site-distribution.domain_name}"
+  value = aws_cloudfront_distribution.site-distribution.domain_name
 }
 
 output "cloudfront_hosted_zone_id" {
-  value = "${aws_cloudfront_distribution.site-distribution.hosted_zone_id}"
+  value = aws_cloudfront_distribution.site-distribution.hosted_zone_id
 }
+

--- a/apps/mdn/insights/modules/cdn/variables.tf
+++ b/apps/mdn/insights/modules/cdn/variables.tf
@@ -2,7 +2,8 @@ variable "region" {
   default = "us-west-2"
 }
 
-variable "environment" {}
+variable "environment" {
+}
 
 variable "bucket_name" {
   default = "insights"
@@ -21,7 +22,7 @@ variable "cloudfront_enabled" {
 }
 
 variable "cloudfront_aliases" {
-  type = "list"
+  type = list(string)
 }
 
 variable "cloudfront_protocol_policy" {
@@ -32,8 +33,10 @@ variable "enable_ipv6" {
   default = "true"
 }
 
-variable "acm_certificate_arn" {}
+variable "acm_certificate_arn" {
+}
 
 variable "event_trigger" {
   default = "lambda-headers.handler"
 }
+

--- a/apps/mdn/insights/modules/dns/main.tf
+++ b/apps/mdn/insights/modules/dns/main.tf
@@ -1,7 +1,8 @@
 resource "aws_route53_record" "main" {
-  zone_id = "${var.domain-zone-id}"
-  name    = "${var.domain-name}"
+  zone_id = var.domain-zone-id
+  name    = var.domain-name
   type    = "CNAME"
-  ttl     = "${var.domain-ttl}"
-  records = ["${var.domain-name-alias}"]
+  ttl     = var.domain-ttl
+  records = [var.domain-name-alias]
 }
+

--- a/apps/mdn/insights/modules/dns/variables.tf
+++ b/apps/mdn/insights/modules/dns/variables.tf
@@ -1,8 +1,11 @@
-variable "domain-zone-id" {}
+variable "domain-zone-id" {
+}
 
-variable "domain-name" {}
+variable "domain-name" {
+}
 
-variable "domain-name-alias" {}
+variable "domain-name-alias" {
+}
 
 variable "evaluate-target-health" {
   default = "true"
@@ -11,3 +14,4 @@ variable "evaluate-target-health" {
 variable "domain-ttl" {
   default = "300"
 }
+

--- a/apps/mdn/insights/outputs.tf
+++ b/apps/mdn/insights/outputs.tf
@@ -1,7 +1,8 @@
 output "insights_stage_cloudfront_domain" {
-  value = "${module.insights-stage.cloudfront_domain}"
+  value = module.insights-stage.cloudfront_domain
 }
 
 output "insights_prod_cloudfront_domain" {
-  value = "${module.insights-prod.cloudfront_domain}"
+  value = module.insights-prod.cloudfront_domain
 }
+

--- a/apps/mdn/insights/variables.tf
+++ b/apps/mdn/insights/variables.tf
@@ -1,3 +1,4 @@
 variable "region" {
   default = "us-west-2"
 }
+

--- a/apps/mdn/insights/versions.tf
+++ b/apps/mdn/insights/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/apps/mdn/interactive-examples/inputs.tf
+++ b/apps/mdn/interactive-examples/inputs.tf
@@ -1,3 +1,4 @@
-variable region {
+variable "region" {
   default = "us-west-2"
 }
+

--- a/apps/mdn/interactive-examples/main.tf
+++ b/apps/mdn/interactive-examples/main.tf
@@ -1,5 +1,6 @@
 provider "aws" {
-  region = "${var.region}"
+  region  = var.region
+  version = "~> 2"
 }
 
 terraform {
@@ -16,13 +17,14 @@ provider "aws" {
 }
 
 data "aws_acm_certificate" "interactive-example" {
-  provider = "aws.aws-acm"
+  provider = aws.aws-acm
   domain   = "interactive-examples.mdn.mozilla.net"
   statuses = ["ISSUED"]
 }
 
 module "interactive-example" {
   source              = "./tf"
-  acm_certificate_arn = "${data.aws_acm_certificate.interactive-example.arn}"
+  acm_certificate_arn = data.aws_acm_certificate.interactive-example.arn
   cdn_aliases         = ["interactive-examples.mdn.mozit.cloud", "interactive-examples.mdn.mozilla.net"]
 }
+

--- a/apps/mdn/interactive-examples/output.tf
+++ b/apps/mdn/interactive-examples/output.tf
@@ -1,11 +1,12 @@
 output "interactive-example-bucket" {
-  value = "${module.interactive-example.interactive-example-bucket}"
+  value = module.interactive-example.interactive-example-bucket
 }
 
 output "interactive-example-cloudfront-id" {
-  value = "${module.interactive-example.interactive-example-cloudfront-id}"
+  value = module.interactive-example.interactive-example-cloudfront-id
 }
 
 output "interactive-example-cloudfront-domain" {
-  value = "${module.interactive-example.interactive-example-cloudfront-domain}"
+  value = module.interactive-example.interactive-example-cloudfront-domain
 }
+

--- a/apps/mdn/interactive-examples/tf/outputs.tf
+++ b/apps/mdn/interactive-examples/tf/outputs.tf
@@ -1,11 +1,12 @@
 output "interactive-example-bucket" {
-  value = "${aws_s3_bucket.interactive-example.id}"
+  value = aws_s3_bucket.interactive-example.id
 }
 
 output "interactive-example-cloudfront-id" {
-  value = "${aws_cloudfront_distribution.s3_distribution.id}"
+  value = aws_cloudfront_distribution.s3_distribution.id
 }
 
 output "interactive-example-cloudfront-domain" {
-  value = "${aws_cloudfront_distribution.s3_distribution.domain_name}"
+  value = aws_cloudfront_distribution.s3_distribution.domain_name
 }
+

--- a/apps/mdn/interactive-examples/tf/variables.tf
+++ b/apps/mdn/interactive-examples/tf/variables.tf
@@ -8,7 +8,7 @@ variable "interactive-example-bucket" {
 
 variable "hosted-zone-id-defs" {
   # See: https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints
-  type = "map"
+  type = map(string)
 
   default = {
     us-east-1 = "Z3AQBSTGFYJSTF"
@@ -16,12 +16,14 @@ variable "hosted-zone-id-defs" {
   }
 }
 
-variable "acm_certificate_arn" {}
+variable "acm_certificate_arn" {
+}
 
 variable "origin_id" {
   default = "MDNInteractive"
 }
 
 variable "cdn_aliases" {
-  type = "list"
+  type = list(string)
 }
+

--- a/apps/mdn/interactive-examples/versions.tf
+++ b/apps/mdn/interactive-examples/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/apps/mdn/mdn-dev/main.tf
+++ b/apps/mdn/mdn-dev/main.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   version = "~> 2"
-  region  = "${var.region}"
+  region  = var.region
 }
 
 provider "aws" {
@@ -19,7 +19,7 @@ terraform {
 data "terraform_remote_state" "dns" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "mdn-state-4e366a3ac64d1b4022c8b5e35efbd288"
     key    = "terraform/dns"
     region = "us-west-2"
@@ -27,29 +27,30 @@ data "terraform_remote_state" "dns" {
 }
 
 data "aws_acm_certificate" "mdn-dev" {
-  provider = "aws.aws-acm"
+  provider = aws.aws-acm
   domain   = "mdn.dev"
   statuses = ["ISSUED"]
 }
 
 module "dns-mozit" {
   source            = "./modules/dns"
-  domain-zone-id    = "${data.terraform_remote_state.dns.master-zone}"
+  domain-zone-id    = data.terraform_remote_state.dns.outputs.master-zone
   domain-name       = "mdn-dev.mdn.mozit.cloud"
-  domain-name-alias = "${module.mdn-dev.cloudfront_domain}"
-  alias-zone-id     = "${module.mdn-dev.cloudfront_hosted_zone_id}"
+  domain-name-alias = module.mdn-dev.cloudfront_domain
+  alias-zone-id     = module.mdn-dev.cloudfront_hosted_zone_id
 }
 
 module "dns-mdn-dev" {
   source            = "./modules/dns"
-  domain-zone-id    = "${data.terraform_remote_state.dns.mdn-dev-zone}"
+  domain-zone-id    = data.terraform_remote_state.dns.outputs.mdn-dev-zone
   domain-name       = "mdn.dev"
-  domain-name-alias = "${module.mdn-dev.cloudfront_domain}"
-  alias-zone-id     = "${module.mdn-dev.cloudfront_hosted_zone_id}"
+  domain-name-alias = module.mdn-dev.cloudfront_domain
+  alias-zone-id     = module.mdn-dev.cloudfront_hosted_zone_id
 }
 
 module "mdn-dev" {
   source              = "./modules/cdn"
   cloudfront_aliases  = ["mdn.dev", "mdn-dev.mdn.mozit.cloud"]
-  acm_certificate_arn = "${data.aws_acm_certificate.mdn-dev.arn}"
+  acm_certificate_arn = data.aws_acm_certificate.mdn-dev.arn
 }
+

--- a/apps/mdn/mdn-dev/modules/cdn/outputs.tf
+++ b/apps/mdn/mdn-dev/modules/cdn/outputs.tf
@@ -1,15 +1,16 @@
 output "site_bucket" {
-  value = "${aws_s3_bucket.site-bucket.id}"
+  value = aws_s3_bucket.site-bucket.id
 }
 
 output "cloudfront_id" {
-  value = "${aws_cloudfront_distribution.site-distribution.id}"
+  value = aws_cloudfront_distribution.site-distribution.id
 }
 
 output "cloudfront_domain" {
-  value = "${aws_cloudfront_distribution.site-distribution.domain_name}"
+  value = aws_cloudfront_distribution.site-distribution.domain_name
 }
 
 output "cloudfront_hosted_zone_id" {
-  value = "${aws_cloudfront_distribution.site-distribution.hosted_zone_id}"
+  value = aws_cloudfront_distribution.site-distribution.hosted_zone_id
 }
+

--- a/apps/mdn/mdn-dev/modules/cdn/variables.tf
+++ b/apps/mdn/mdn-dev/modules/cdn/variables.tf
@@ -19,7 +19,7 @@ variable "cloudfront_enable" {
 }
 
 variable "cloudfront_aliases" {
-  type = "list"
+  type = list(string)
 }
 
 variable "cloudfront_protocol_policy" {
@@ -30,8 +30,10 @@ variable "enable_ipv6" {
   default = "true"
 }
 
-variable "acm_certificate_arn" {}
+variable "acm_certificate_arn" {
+}
 
 variable "event_trigger" {
   default = "lambda-headers.handler"
 }
+

--- a/apps/mdn/mdn-dev/modules/dns/main.tf
+++ b/apps/mdn/mdn-dev/modules/dns/main.tf
@@ -1,21 +1,22 @@
 resource "aws_route53_record" "main" {
-  zone_id = "${var.domain-zone-id}"
-  name    = "${var.domain-name}"
+  zone_id = var.domain-zone-id
+  name    = var.domain-name
 
   type = "A"
 
   alias {
-    name                   = "${var.domain-name-alias}"
-    zone_id                = "${var.alias-zone-id}"
-    evaluate_target_health = "${var.evaluate-target-health}"
+    name                   = var.domain-name-alias
+    zone_id                = var.alias-zone-id
+    evaluate_target_health = var.evaluate-target-health
   }
 }
 
 resource "aws_route53_record" "www" {
-  zone_id = "${var.domain-zone-id}"
+  zone_id = var.domain-zone-id
   name    = "www.${var.domain-name}"
 
   type    = "CNAME"
-  ttl     = "${var.domain-ttl}"
-  records = ["${aws_route53_record.main.fqdn}"]
+  ttl     = var.domain-ttl
+  records = [aws_route53_record.main.fqdn]
 }
+

--- a/apps/mdn/mdn-dev/modules/dns/variables.tf
+++ b/apps/mdn/mdn-dev/modules/dns/variables.tf
@@ -1,10 +1,14 @@
-variable "domain-zone-id" {}
+variable "domain-zone-id" {
+}
 
-variable "domain-name" {}
+variable "domain-name" {
+}
 
-variable "domain-name-alias" {}
+variable "domain-name-alias" {
+}
 
-variable "alias-zone-id" {}
+variable "alias-zone-id" {
+}
 
 variable "evaluate-target-health" {
   default = "true"
@@ -13,3 +17,4 @@ variable "evaluate-target-health" {
 variable "domain-ttl" {
   default = "600"
 }
+

--- a/apps/mdn/mdn-dev/outputs.tf
+++ b/apps/mdn/mdn-dev/outputs.tf
@@ -1,3 +1,4 @@
 output "cloudfront_domain" {
-  value = "${module.mdn-dev.cloudfront_domain}"
+  value = module.mdn-dev.cloudfront_domain
 }
+

--- a/apps/mdn/mdn-dev/variables.tf
+++ b/apps/mdn/mdn-dev/variables.tf
@@ -1,3 +1,4 @@
 variable "region" {
   default = "us-west-2"
 }
+

--- a/apps/mdn/mdn-dev/versions.tf
+++ b/apps/mdn/mdn-dev/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/apps/mdn/mdn-samples/data.tf
+++ b/apps/mdn/mdn-samples/data.tf
@@ -1,14 +1,14 @@
-data terraform_remote_state "vpc-us-west-2" {
+data "terraform_remote_state" "vpc-us-west-2" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "mdn-state-4e366a3ac64d1b4022c8b5e35efbd288"
     key    = "terraform/us-west-2/vpc"
     region = "us-west-2"
   }
 }
 
-data aws_ami "centos" {
+data "aws_ami" "centos" {
   most_recent = true
 
   filter {
@@ -24,9 +24,4 @@ data aws_ami "centos" {
   }
 
   owners = ["aws-marketplace"]
-}
-
-data aws_acm_certificate "mdn-samples" {
-  domain   = "mdn-samples.us-west-2.mdn.mozit.cloud"
-  statuses = ["ISSUED"]
 }

--- a/apps/mdn/mdn-samples/outputs.tf
+++ b/apps/mdn/mdn-samples/outputs.tf
@@ -1,3 +1,4 @@
 output "eip_address" {
-  value = "${aws_eip.mdn-samples.public_ip}"
+  value = aws_eip.mdn-samples.public_ip
 }
+

--- a/apps/mdn/mdn-samples/variables.tf
+++ b/apps/mdn/mdn-samples/variables.tf
@@ -13,3 +13,4 @@ variable "instance_type" {
 variable "domain" {
   default = "mdn.mozit.cloud"
 }
+

--- a/apps/mdn/mdn-samples/versions.tf
+++ b/apps/mdn/mdn-samples/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Update terraform code to support terraform 0.12, these changes are
generated by the command `terraform 0.12upgrade -yes` and has been made
to the following MDN apps

 - insights
 - interactive-examples
 - mdn-dev
 - mdn-samples

I've ran an apply against all of them and they have applied cleanly so
the states are now update to the newest version of terraform.