### PR TITLE
Setup an ssh instance for the sole purpose of ssh tunnelling

### DIFF
--- a/apps/mdn/mdn-aws/infra/main.tf
+++ b/apps/mdn/mdn-aws/infra/main.tf
@@ -1,5 +1,6 @@
 provider "aws" {
-  region = var.region
+  region  = var.region
+  version = "~>2"
 }
 
 terraform {
@@ -323,4 +324,3 @@ module "upload-user-prod" {
     data.terraform_remote_state.eks-us-west-2.outputs.mdn_apps_a_worker_iam_role_arn,
   ]
 }
-

--- a/apps/mdn/ssh-tunnel/data.tf
+++ b/apps/mdn/ssh-tunnel/data.tf
@@ -1,0 +1,72 @@
+data terraform_remote_state "vpc-us-west-2" {
+  backend = "s3"
+
+  config = {
+    bucket = "mdn-state-4e366a3ac64d1b4022c8b5e35efbd288"
+    key    = "terraform/us-west-2/vpc"
+    region = "us-west-2"
+  }
+}
+
+data terraform_remote_state "dns" {
+  backend = "s3"
+  config = {
+    bucket = "mdn-state-4e366a3ac64d1b4022c8b5e35efbd288"
+    key    = "terraform/dns"
+    region = "us-west-2"
+  }
+}
+
+data "aws_ami" "ubuntu_linux" {
+  most_recent = true
+  owners      = ["099720109477"]
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-*-${var.ubuntu_version}-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+data "aws_iam_policy_document" "ssh-tunnel" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "associate-eip" {
+  statement {
+    sid       = "AllowEipAssociate"
+    effect    = "Allow"
+    actions   = ["ec2:AssociateAddress"]
+    resources = ["*"]
+  }
+}
+
+locals {
+  template = templatefile("${path.module}/templates/userdata.sh", {
+    region       = var.region,
+    eip_id       = aws_eip.ssh-tunnel.id,
+    github_users = var.github_users
+  })
+}
+
+data "template_cloudinit_config" "config" {
+  gzip          = true
+  base64_encode = true
+
+  part {
+    filename     = "01-user-data.sh"
+    content_type = "text/x-shellscript"
+    content      = local.template
+  }
+}

--- a/apps/mdn/ssh-tunnel/dns.tf
+++ b/apps/mdn/ssh-tunnel/dns.tf
@@ -1,0 +1,10 @@
+
+resource "aws_route53_record" "ssh-tunnel" {
+  zone_id = data.terraform_remote_state.dns.outputs.us-west-2-zone-id
+  name    = "tunnel"
+  type    = "A"
+  ttl     = "300"
+  records = [
+    aws_eip.ssh-tunnel.public_ip
+  ]
+}

--- a/apps/mdn/ssh-tunnel/main.tf
+++ b/apps/mdn/ssh-tunnel/main.tf
@@ -1,0 +1,126 @@
+
+locals {
+  prefix = "ssh-tunnel"
+
+  default_tags = {
+    Environment = "prod"
+    Service     = "ssh-tunnel"
+    Region      = var.region
+    Terraform   = true
+  }
+}
+
+resource "aws_eip" "ssh-tunnel" {
+  vpc = true
+
+  tags = merge(
+    {
+      Name = "${local.prefix}-eip"
+    },
+    local.default_tags
+  )
+}
+
+resource "aws_security_group" "ssh-tunnel" {
+  name        = "${local.prefix}-sg"
+  description = "Allow inbound traffic to ${local.prefix}"
+  vpc_id      = data.terraform_remote_state.vpc-us-west-2.outputs.vpc_id
+
+  tags = merge(
+    {
+      Name = "${local.prefix}-sg"
+    },
+    local.default_tags
+  )
+}
+
+resource "aws_security_group_rule" "allow_ingress_ssh" {
+  security_group_id = aws_security_group.ssh-tunnel.id
+  type              = "ingress"
+  from_port         = "22"
+  to_port           = "22"
+  protocol          = "tcp"
+
+  cidr_blocks = [
+    "0.0.0.0/0"
+  ]
+}
+
+resource "aws_security_group_rule" "allow_egress_all" {
+  security_group_id = aws_security_group.ssh-tunnel.id
+  type              = "egress"
+  from_port         = "0"
+  to_port           = "0"
+  protocol          = "-1"
+  cidr_blocks = [
+    "0.0.0.0/0"
+  ]
+}
+
+resource "aws_iam_instance_profile" "ssh-tunnel" {
+  name = "${local.prefix}-${var.region}-instance-profile"
+  role = aws_iam_role.ssh-tunnel.name
+}
+
+resource "aws_iam_role" "ssh-tunnel" {
+  name               = "${local.prefix}-${var.region}-role"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.ssh-tunnel.json
+}
+
+resource "aws_iam_role_policy" "ssh-tunnel" {
+  name   = "eip-allow-${var.region}"
+  role   = aws_iam_role.ssh-tunnel.id
+  policy = data.aws_iam_policy_document.associate-eip.json
+}
+
+resource "aws_key_pair" "ssh-tunnel" {
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  key_name   = "ssh-tunnel"
+  public_key = var.ssh_pubkey
+}
+
+
+module "asg" {
+  source  = "terraform-aws-modules/autoscaling/aws"
+  version = "~> 3.0"
+
+  name    = local.prefix
+  lc_name = "${local.prefix}-lc"
+
+  image_id                     = data.aws_ami.ubuntu_linux.id
+  instance_type                = var.instance_type
+  security_groups              = [aws_security_group.ssh-tunnel.id]
+  associate_public_ip_address  = true
+  recreate_asg_when_lc_changes = true
+  key_name                     = aws_key_pair.ssh-tunnel.key_name
+
+  root_block_device = [
+    {
+      volume_size           = "10"
+      volume_type           = "gp2"
+      delete_on_termination = true
+    }
+  ]
+
+  tags = flatten([
+    for key in keys(local.default_tags) : {
+      key                 = key
+      value               = local.default_tags[key]
+      propagate_at_launch = true
+    }
+  ])
+
+  asg_name             = local.prefix
+  vpc_zone_identifier  = data.terraform_remote_state.vpc-us-west-2.outputs.public_subnets
+  health_check_type    = "EC2"
+  min_size             = 1
+  max_size             = 1
+  desired_capacity     = 1
+  spot_price           = var.spot_price
+  iam_instance_profile = aws_iam_instance_profile.ssh-tunnel.name
+  user_data            = data.template_cloudinit_config.config.rendered
+}

--- a/apps/mdn/ssh-tunnel/outputs.tf
+++ b/apps/mdn/ssh-tunnel/outputs.tf
@@ -1,0 +1,8 @@
+
+output "tunnel_server_ip" {
+  value = aws_eip.ssh-tunnel.public_ip
+}
+
+output "tunnel_fqdn" {
+  value = aws_route53_record.ssh-tunnel.fqdn
+}

--- a/apps/mdn/ssh-tunnel/providers.tf
+++ b/apps/mdn/ssh-tunnel/providers.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = var.region
+  version = "~> 2"
+}

--- a/apps/mdn/ssh-tunnel/state.tf
+++ b/apps/mdn/ssh-tunnel/state.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "mdn-state-4e366a3ac64d1b4022c8b5e35efbd288"
+    key    = "terraform/ssh-tunnel"
+    region = "us-west-2"
+  }
+}

--- a/apps/mdn/ssh-tunnel/templates/userdata.sh
+++ b/apps/mdn/ssh-tunnel/templates/userdata.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+declare -A github_urls
+
+# This  section is generated
+%{ for users in github_users ~}
+github_urls[${users}]="https://github.com/${users}.keys"
+%{ endfor }
+# End generated
+
+function pre_req() {
+    apt-get --quiet update
+    apt-get install  --no-install-recommends -qy vim sshuttle python3-pip fail2ban
+    curl -o /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py
+    pip3 install awscli
+}
+
+function associate_eip() {
+    # Get EIP id from userdata and dump it to the filesystem
+    echo "${eip_id}" > /etc/aws_eip_id
+    instance_id=$(/usr/bin/curl -fqs http://169.254.169.254/latest/meta-data/instance-id)
+    aws ec2 associate-address --instance-id "$${instance_id}" --allocation-id ${eip_id} --region ${region}
+}
+
+function create_users() {
+    local default_user
+    default_user="tunnel"
+
+    adduser --disabled-password --gecos "" "$${default_user}"
+    mkdir "/home/$${default_user}/.ssh"
+
+    for user in "$${!github_urls[@]}"; do
+        echo "Pulling key from github for user $${user}"
+        echo "# $${user}" >> "/home/$${default_user}/.ssh/authorized_keys"
+        curl -sS "$${github_urls[$user]}" >> "/home/$${default_user}/.ssh/authorized_keys"
+        echo "" >> "/home/$${default_user}/.ssh/authorized_keys"
+    done
+
+    chown -R tunnel:tunnel "/home/$${default_user}/.ssh"
+    chmod -R go-rx "/home/$${default_user}/.ssh"
+
+}
+
+function main() {
+    pre_req
+    associate_eip
+    create_users
+}
+
+main

--- a/apps/mdn/ssh-tunnel/variables.tf
+++ b/apps/mdn/ssh-tunnel/variables.tf
@@ -1,0 +1,24 @@
+variable "region" {
+  default = "us-west-2"
+}
+
+variable "ubuntu_version" {
+  default = "18.04"
+}
+
+variable "instance_type" {
+  default = "t3.nano"
+}
+
+variable "spot_price" {
+  default = "0.0016"
+}
+
+variable "ssh_pubkey" {
+  default = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQClyrknFMLehaBAAAU8L3xTHfY03E8yB7sJ4NmnJgqAjn7yShdW1JCjE69FzWVnFtEUF6GRFCDyOPPQeH7RJZkFKMgB2VqDTi6Cz2k4ltzYLbQulbLd9tc+NYQwY/y/ijCFFawUWn8b6rJaIPNf5qHhEih3RDqYRc6RiZIW2nvwWZQjD3XUMnMWeri5wm+XZpOb69cIVXlB5yNzqBzeOAf5+zXYWaXW6PqPXfNEZWOy+NQLld0WVgxRZsU8WBGBL96l0YwmIaBVTcIATsTlwqdR7Jc1p2/lT5g3aDghCu0dSgJ7rhVhCnuK08jmy40g+K88N09sQJzTn1WzLzPewU3bU9LeyYU88PDlw6f+2FAKBeLLea498/eS6/mat0A93JmKvpSe4FfYR7BM8W4qNUKVFacOkJTYkEOJuFSK/mb2xl9JtuEdjAQw70s2I+4QXSGxowjA8NCegDK/a+00GbsT2M8JKV1LmH64Itx3uux2LW76hatNFAzohbCdRu3p/7B+QUn8dmTCRKJVC+hfpyKU2O1eAtknJww0LdWa/3crgkLIdA/hxWkAgE1csPXmLwWu7uPO6QcvzWK5oXBb/zgZJ8PmJtl/hDpuae3wBv9BJ7Eq6Eznp784Lan3aMHJs2XqKJTpUQ5RkZdSog4SUj8Wjxw5WLevJXPYrxyX1XfFqw== mdn"
+}
+
+variable "github_users" {
+  type    = list(string)
+  default = ["limed", "escattone", "Gregoor", "peterbe", "tobinmori", "schalkneethling"]
+}


### PR DESCRIPTION
This setups a simple EC2 instance with a bunch of ssh keys for the sole
purpose of doing ssh tunneling. This is to allow users who are granted
access to be able to tunnel into the vpc without having to setup a vpn