### PR TITLE
Initial add of media-sync script

### DIFF
--- a/apps/mdn/mdn-aws/infra/main.tf
+++ b/apps/mdn/mdn-aws/infra/main.tf
@@ -277,7 +277,6 @@ module "upload-user-stage" {
   eks_worker_role_arn = [
     data.terraform_remote_state.kops-us-west-2.outputs.nodes_role_arn,
     data.terraform_remote_state.kops-eu-central-1.outputs.nodes_role_arn,
-    data.terraform_remote_state.eks-us-west-2.outputs.mdn_apps_a_worker_iam_role_arn,
   ]
 }
 
@@ -294,6 +293,14 @@ module "upload-user-prod" {
   eks_worker_role_arn = [
     data.terraform_remote_state.kops-us-west-2.outputs.nodes_role_arn,
     data.terraform_remote_state.kops-eu-central-1.outputs.nodes_role_arn,
-    data.terraform_remote_state.eks-us-west-2.outputs.mdn_apps_a_worker_iam_role_arn,
   ]
+}
+
+# Create role for media sync
+module "media-sync-roles" {
+  source                  = "./modules/media-sync"
+  cluster_oidc_issuer_url = data.terraform_remote_state.eks-us-west-2.outputs.mdn_cluster_oidc_issuer_url
+  stage_bucket            = module.media-bucket-stage.bucket_name
+  prod_bucket             = module.media-bucket-prod.bucket_name
+
 }

--- a/apps/mdn/mdn-aws/infra/modules/media-sync/main.tf
+++ b/apps/mdn/mdn-aws/infra/modules/media-sync/main.tf
@@ -25,4 +25,15 @@ data "aws_iam_policy_document" "media-sync" {
       "arn:aws:s3:::${var.prod_bucket}/*"
     ]
   }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.stage_bucket}",
+      "arn:aws:s3:::${var.prod_bucket}"
+    ]
+  }
 }

--- a/apps/mdn/mdn-aws/infra/modules/media-sync/main.tf
+++ b/apps/mdn/mdn-aws/infra/modules/media-sync/main.tf
@@ -1,0 +1,28 @@
+module "iam_assumable_role" {
+  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version                       = "~> v2.10.0"
+  create_role                   = true
+  role_name                     = "media-sync-role"
+  provider_url                  = replace(var.cluster_oidc_issuer_url, "https://", "")
+  role_policy_arns              = [aws_iam_policy.media-sync.arn]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:${var.service_account_namespace}:${var.service_account_name}"]
+}
+
+resource "aws_iam_policy" "media-sync" {
+  name_prefix = "media-sync"
+  description = "Allow the 2 media / attachment buckets to sync"
+  policy      = data.aws_iam_policy_document.media-sync.json
+}
+
+data "aws_iam_policy_document" "media-sync" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:*"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.stage_bucket}/*",
+      "arn:aws:s3:::${var.prod_bucket}/*"
+    ]
+  }
+}

--- a/apps/mdn/mdn-aws/infra/modules/media-sync/outputs.tf
+++ b/apps/mdn/mdn-aws/infra/modules/media-sync/outputs.tf
@@ -1,0 +1,7 @@
+output "role_arn" {
+  value = module.iam_assumable_role.this_iam_role_arn
+}
+
+output "role_name" {
+  value = module.iam_assumable_role.this_iam_role_name
+}

--- a/apps/mdn/mdn-aws/infra/modules/media-sync/variables.tf
+++ b/apps/mdn/mdn-aws/infra/modules/media-sync/variables.tf
@@ -1,0 +1,17 @@
+variable region {
+  default = "us-west-2"
+}
+
+variable "cluster_oidc_issuer_url" {}
+
+variable "service_account_namespace" {
+  default = "mdn-cron"
+}
+
+variable "service_account_name" {
+  default = "media-sync"
+}
+
+variable "stage_bucket" {}
+
+variable "prod_bucket" {}

--- a/apps/mdn/mdn-aws/infra/outputs.tf
+++ b/apps/mdn/mdn-aws/infra/outputs.tf
@@ -58,7 +58,11 @@ output "worf_user" {
   value = module.security.worf_user
 }
 
-output "work_user_secret_key" {
+output "worf_user_secret_key" {
   value = module.security.worf_secret_key
+}
+
+output "media-sync-role_arn" {
+  value = module.media-sync-roles.role_arn
 }
 

--- a/apps/mdn/mdn-aws/infra/tf-do
+++ b/apps/mdn/mdn-aws/infra/tf-do
@@ -7,7 +7,7 @@ fi
 
 source ./config.sh
 
-if [ -z ${TF_SECRETS_PATH} ]; then
+if [ -z "${TF_SECRETS_PATH}" ]; then
     echo "Secrets path is not set"
     exit 1
 fi
@@ -27,15 +27,9 @@ show_help() {
     echo -en "	init		Terraform init\n"
     echo -en "	plan		Terraform plan\n"
     echo -en "	apply		Terraform apply\n"
-}
-
-terraform_do() {
-    declare -a _ACTION; _ACTION=( "${@}" )
-
-    if ! terraform "${_ACTION[@]}" ; then
-        echo -e "\033[1;31mERROR: Failed running 'terraform ${_ACTION[*]}'\033[0m"
-        exit 1
-    fi
+    echo -en "  get         Terraform get\n"
+    echo -en "  output      Terraform output\n"
+    echo -en "  refresh     Terraform refresh\n"
 }
 
 init() {
@@ -56,6 +50,10 @@ get() {
 
 output() {
     terraform output
+}
+
+refresh() {
+    terraform refresh -var-file="${TF_SECRETS_PATH}/terraform.tfvars" "${@}"
 }
 
 while [ "$1" != "" ]; do
@@ -83,6 +81,16 @@ while [ "$1" != "" ]; do
         apply )
             shift
             apply "${@}"
+            GOT_COMMAND=1
+        ;;
+        output )
+            shift
+            output "${@}"
+            GOT_COMMAND=1
+        ;;
+        refresh )
+            shift
+            refresh  "${@}"
             GOT_COMMAND=1
         ;;
     esac

--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -239,6 +239,12 @@ export NEW_RELIC_SSR_NAME ?= "ssr-${NEW_RELIC_MONITOR_SUFFIX}"
 export PERCONA_TOOLKIT_NS ?= percona-toolkit
 export PERCONA_TOOLKIT_IMAGE ?= mdnwebdocs/percona-toolkit:226571b
 
+export MEDIA_SYNC_NS ?= mdn-cron
+export MEDIA_SYNC_IMAGE ?= mdnwebdocs/media-sync
+export MEDIA_SYNC_IMAGE_TAG ?= f20ea9d
+export MEDIA_SYNC_DEBUG_MODE ?= false
+export MEDIA_SYNC_ROLE_ARN ?= "arn:aws:iam::178589013767:role/media-sync-role"
+
 ###############################
 ### core tasks
 
@@ -549,6 +555,15 @@ k8s-percona-toolkit-ptkill: check-service-env
 
 k8s-delete-percona-toolkit-ptkill: check-service-env
 	${KUBECTL} delete -n ${PERCONA_TOOLKIT_NS} --ignore-not-found deployment percona-toolkit-ptkill
+
+k8s-media-sync-cron: check-service-env
+	j2 mdn-media-sync-cron.yaml.j2 | ${KUBECTL} apply -n ${MEDIA_SYNC_NS} -f -
+
+k8s-delete-media-sync-cron:
+	${KUBECTL} delete -n ${MEDIA_SYNC_NS} --ignore-not-found cronjob  mdn-media-sync
+
+test-k8s-media-sync-cron: check-service-env
+	j2 mdn-media-sync-cron.yaml.j2 | kubeval --strict --ignore-missing-schemas
 
 
 ### end administrative tasks

--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -241,7 +241,7 @@ export PERCONA_TOOLKIT_IMAGE ?= mdnwebdocs/percona-toolkit:226571b
 
 export MEDIA_SYNC_NS ?= mdn-cron
 export MEDIA_SYNC_IMAGE ?= mdnwebdocs/media-sync
-export MEDIA_SYNC_IMAGE_TAG ?= f20ea9d
+export MEDIA_SYNC_IMAGE_TAG ?= 43bafbf
 export MEDIA_SYNC_DEBUG_MODE ?= false
 export MEDIA_SYNC_ROLE_ARN ?= "arn:aws:iam::178589013767:role/media-sync-role"
 

--- a/apps/mdn/mdn-aws/k8s/mdn-media-sync-cron.yaml.j2
+++ b/apps/mdn/mdn-aws/k8s/mdn-media-sync-cron.yaml.j2
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    eks.amazonaws.com/role-arn: {{ MEDIA_SYNC_ROLE_ARN }}
+  labels:
+    app: mdn-media-sync
+    service: mdn
+  name: media-sync
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: mdn-media-sync
+  labels:
+    app: mdn-media-sync
+    service: mdn
+spec:
+  schedule: "0 0 * * *"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: {{ FAILED_JOBS_HISTORY_LIMIT }}
+  successfulJobsHistoryLimit: {{ SUCCESSFUL_JOBS_HISTORY_LIMIT }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          serviceAccountName: media-sync
+          containers:
+            - name: mdn-media-sync
+              image: {{ MEDIA_SYNC_IMAGE }}:{{ MEDIA_SYNC_IMAGE_TAG }}
+              {%- if MEDIA_SYNC_DEBUG_MODE == 'true' %}
+              command: [ "/bin/bash", "-c", "--" ]
+              args: [ "while true; do sleep 30; done;" ]
+              {%- endif %}
+              env:
+                - name: DMS_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: mdn-media-sync
+                      key: dms_url

--- a/k8s/clusters/eks/us-west-2/outputs.tf
+++ b/k8s/clusters/eks/us-west-2/outputs.tf
@@ -18,6 +18,10 @@ output "mdn_apps_a_primary_security_group_id" {
   value = module.mdn-apps-a.cluster_primary_security_group_id
 }
 
+output "mdn_apps_a_cluster_oidc_issuer_url" {
+  value = module.mdn-apps-a.cluster_oidc_issuer_url
+}
+
 output "mdn_cluster_name" {
   value = module.mdn.cluster_id
 }
@@ -28,5 +32,9 @@ output "mdn_cluster_endpoint" {
 
 output "mdn_cluster_primary_security_group_id" {
   value = module.mdn.cluster_primary_security_group_id
+}
+
+output "mdn_cluster_oidc_issuer_url" {
+  value = module.mdn.cluster_oidc_issuer_url
 }
 

--- a/k8s/tools/README.md
+++ b/k8s/tools/README.md
@@ -1,27 +1,8 @@
 # Tools
+Various administrative and tools containers to help manage our k8s cluster
 
-### `k8s_ssh_security.ssh`
+Contains the following:
 
-This script grants or revokes SSH access to a kops Kubernetes cluster.
-
-```
-~/infra/k8s/tools$ ./k8s_ssh_security.sh --help
----------------------------------------------
-You must source config.sh to use this script.
-
-Show current security groups
-k8s_ssh_security.sh --show
-
-Disable external ssh into K8s:
-k8s_ssh_security.sh --disable
-
-Disable ssh access from this public ip into K8s:
-k8s_ssh_security.sh --disable --myip
-
-Enable 0.0.0.0/0 ssh access into K8s:
-k8s_ssh_security.sh --enable
-
-Enable ssh access from this public ip into K8s:
-k8s_ssh_security.sh --enable --myip
-```
-
+- admin node which is deployment of a long running pod to run various admin jobs
+- block-aws a deployment to block the AWS metadata endpoint
+- media-sync simple container to sync the attachments from the prod environment to stage

--- a/k8s/tools/media-sync/Dockerfile
+++ b/k8s/tools/media-sync/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl && \
+	pip install --no-cache --no-cache-dir awscli && \
+	mkdir -p /app && \
+	apt-get purge -y --auto-remove && \
+	apt-get clean -y && \
+	apt-get autoclean -y && \
+	rm -rf /var/lib/apt/lists/* /var/lib/{apt,dpkg,cache,log}/ /var/tmp/*
+
+WORKDIR /app
+
+COPY ./media-sync.sh /app
+CMD [ "/app/media-sync.sh" ]

--- a/k8s/tools/media-sync/build.sh
+++ b/k8s/tools/media-sync/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+#!/bin/bash
+docker build . -t mdnwebdocs/media-sync:${GIT_COMMIT:=$(git rev-parse --short HEAD)}
+docker push mdnwebdocs/media-sync:${GIT_COMMIT}

--- a/k8s/tools/media-sync/media-sync.sh
+++ b/k8s/tools/media-sync/media-sync.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+PROD_MEDIA_BUCKET=${PROD_MEDIA_BUCKET:-mdn-media-prod}
+STAGE_MEDIA_BUCKET=${STAGE_MEDIA_BUCKET:-mdn-media-stage}
+DMS_URL=${DMS_URL}
+OPTIONS="--exclude 'sitemaps/*' --exclude sitemap.xml --cache-control max-age=31536000,public,immutable"
+
+if [ -z "${DMS_URL}" ]; then
+    echo "No DMS URL"
+    exit 1
+fi
+
+aws s3 sync ${OPTIONS} "s3://${PROD_MEDIA_BUCKET}/" "s3://${STAGE_MEDIA_BUCKET}/"
+RV=$?
+
+if [ "${RV}" -eq 0 ]; then
+    curl -d "s=${RV}" -s "${DMS_URL}"
+fi

--- a/k8s/tools/media-sync/media-sync.sh
+++ b/k8s/tools/media-sync/media-sync.sh
@@ -7,7 +7,7 @@ set -o pipefail
 PROD_MEDIA_BUCKET=${PROD_MEDIA_BUCKET:-mdn-media-prod}
 STAGE_MEDIA_BUCKET=${STAGE_MEDIA_BUCKET:-mdn-media-stage}
 DMS_URL=${DMS_URL}
-OPTIONS="--exclude 'sitemaps/*' --exclude sitemap.xml --cache-control max-age=31536000,public,immutable"
+OPTIONS="--exclude 'sitemaps/*' --exclude 'sitemap.xml' --cache-control max-age=31536000,public,immutable"
 
 if [ -z "${DMS_URL}" ]; then
     echo "No DMS URL"


### PR DESCRIPTION
This PR Includes the initial addition of the media-sync script which
syncs the media buckets from prod to stage nightly. Summary of work:

- Added media-sync terraform module to create an IAM role to grant
permission to the cronjob to run this tool
- Update Makefile to be able to deploy this cronjob
- Include Dockerfile to be able to build this container
- Various smaller tweaks that came along the way such has updating
readme and the tf-do script