### PR TITLE
[do-not-merge] Update kubeconfig to point to new EKS clusters

### DIFF
--- a/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 echo '--> Setting environment to PROD(MM) in OREGON'
 
-export KUBECONFIG=${HOME}/.kube/oregon.config
+export KUBECONFIG=${HOME}/.kube/mdn-us-west-2.config
 
 # Define defaults for environment variables that personalize the commands.
 export TARGET_ENVIRONMENT=prod

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/prod.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/prod.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 echo '--> Setting environment to PROD in OREGON'
 
-export KUBECONFIG=${HOME}/.kube/oregon.config
+export KUBECONFIG=${HOME}/.kube/mdn-us-west-2.config
 
 # Define defaults for environment variables that personalize the commands.
 export TARGET_ENVIRONMENT=prod


### PR DESCRIPTION
Do not merge first, we will only merge this once our migration to EKS is complete. This switches pushes to push to the  EKS cluster instead of the kops kubernetes clusters