### PR TITLE
Updating eks clusters to 1.15 and prepping mdn cluster for new workloads

### DIFF
--- a/k8s/clusters/eks/modules/eks/autoscaler.tf
+++ b/k8s/clusters/eks/modules/eks/autoscaler.tf
@@ -1,6 +1,6 @@
 module "cluster_autoscaler_role" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "~> v2.6.0"
+  version                       = "~> v2.10.0"
   create_role                   = true
   role_name                     = local.cluster_autoscaler_name_prefix
   provider_url                  = replace(module.eks.cluster_oidc_issuer_url, "https://", "")

--- a/k8s/clusters/eks/us-west-2/locals.tf
+++ b/k8s/clusters/eks/us-west-2/locals.tf
@@ -25,9 +25,9 @@ locals {
 
   mdn_node_groups = {
     default_ng = {
-      desired_capacity = "2"
-      min_capacity     = "2"
-      max_capacity     = "5"
+      desired_capacity = "10"
+      min_capacity     = "10"
+      max_capacity     = "20"
       disk_size        = "100"
       instance_type    = "m5.xlarge"
       key_name         = "mdn"

--- a/k8s/clusters/eks/us-west-2/main.tf
+++ b/k8s/clusters/eks/us-west-2/main.tf
@@ -36,7 +36,7 @@ module "mdn-apps-a" {
   eks_subnets = data.terraform_remote_state.vpc-us-west-2.outputs.public_subnets
 
   cluster_name    = "mdn-apps-a"
-  cluster_version = "1.14"
+  cluster_version = "1.15"
   node_groups     = local.mdn_apps_node_groups
   map_roles       = local.map_roles
   map_users       = local.map_users


### PR DESCRIPTION
Misc changes to upgrade eks cluster for developer-portal and also prep work for mdn to bump up the number of nodes in preparation for MDN's EKS migration