### PR TITLE
EKS Cutover prep

### DIFF
--- a/k8s/clusters/eks/eu-central-1/locals.tf
+++ b/k8s/clusters/eks/eu-central-1/locals.tf
@@ -7,13 +7,15 @@ locals {
   velero_bucket_name = "velero-${module.mdn.cluster_id}-${var.region}-${data.aws_caller_identity.current.account_id}"
 
   mdn_node_groups = {
-    default_ng = {
-      desired_capacity = "3"
-      min_capacity     = "3"
-      max_capacity     = "12"
-      disk_size        = "50"
-      instance_type    = "m5.large"
-      subnets          = data.terraform_remote_state.vpc-eu-central-1.outputs.private_subnets
+    default_ng_1 = {
+      desired_capacity          = "3"
+      min_capacity              = "3"
+      max_capacity              = "12"
+      disk_size                 = "50"
+      instance_type             = "m5.large"
+      key_name                  = "mdn"
+      source_security_group_ids = [module.ssh_sg.ssh_security_group_id]
+      subnets                   = data.terraform_remote_state.vpc-eu-central-1.outputs.public_subnets
 
       k8s_label = {
         Service = "default"
@@ -21,7 +23,7 @@ locals {
       }
 
       additional_tags = {
-        "Name"                              = "mdn-default-ng"
+        "Name"                              = "mdn-default-ng-1"
         "kubernetes.io/cluster/mdn"         = "owned"
         "k8s.io/cluster-autoscaler/enabled" = "true"
       }
@@ -33,13 +35,6 @@ locals {
       username = "maws-admin"
       rolearn  = "arn:aws:iam::178589013767:role/maws-admin"
       groups   = ["system:masters"]
-    },
-    {
-      username = "AdminRole"
-      # This is a bug in k8s, the role in IAM will not match this
-      # file since k8s has issues parsing roles with paths
-      rolearn = "arn:aws:iam::178589013767:role/AdminRole"
-      groups  = ["system:masters"]
     },
     {
       username = "jenkins"

--- a/k8s/clusters/eks/eu-central-1/main.tf
+++ b/k8s/clusters/eks/eu-central-1/main.tf
@@ -6,6 +6,12 @@ terraform {
   }
 }
 
+module "ssh_sg" {
+  source = "../modules/security-groups"
+  region = var.region
+  vpc_id = data.terraform_remote_state.vpc-eu-central-1.outputs.vpc_id
+}
+
 module "mdn" {
   source = "github.com/mozilla-it/terraform-modules//aws/eks?ref=master"
 

--- a/k8s/clusters/eks/modules/security-groups/main.tf
+++ b/k8s/clusters/eks/modules/security-groups/main.tf
@@ -1,0 +1,48 @@
+
+data aws_vpc "this" {
+  id = var.vpc_id
+}
+
+resource "aws_security_group" "ssh" {
+  name_prefix = "eks-allow-ssh-${var.region}-"
+  description = "Allow inbound SSH to managed node"
+  vpc_id      = data.aws_vpc.this.id
+
+  tags = {
+    Name      = "eks-allow-ssh-${var.region}-sg"
+    Terraform = "true"
+    Region    = var.region
+  }
+}
+
+
+resource "aws_security_group_rule" "eks-ingress-ssh-custom" {
+  count             = length(var.ip_whitelist) > 0 ? 1 : 0
+  cidr_blocks       = var.ip_whitelist
+  description       = "Allow VPC Cidr block to ssh in"
+  type              = "ingress"
+  to_port           = 22
+  from_port         = 22
+  protocol          = "tcp"
+  security_group_id = aws_security_group.ssh.id
+}
+
+resource "aws_security_group_rule" "eks-ingress-ssh-vpc" {
+  cidr_blocks       = [data.aws_vpc.this.cidr_block]
+  description       = "Allow VPC Cidr block to ssh in"
+  type              = "ingress"
+  to_port           = 22
+  from_port         = 22
+  protocol          = "tcp"
+  security_group_id = aws_security_group.ssh.id
+}
+
+resource "aws_security_group_rule" "eks-egress-all" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "Allow Outbound all"
+  type              = "egress"
+  to_port           = 0
+  from_port         = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.ssh.id
+}

--- a/k8s/clusters/eks/modules/security-groups/outputs.tf
+++ b/k8s/clusters/eks/modules/security-groups/outputs.tf
@@ -1,0 +1,8 @@
+
+output "ssh_security_group_id" {
+  value = aws_security_group.ssh.id
+}
+
+output "ssh_security_group_arn" {
+  value = aws_security_group.ssh.arn
+}

--- a/k8s/clusters/eks/modules/security-groups/variables.tf
+++ b/k8s/clusters/eks/modules/security-groups/variables.tf
@@ -1,0 +1,10 @@
+variable "region" {
+  default = "us-west-2"
+}
+
+variable "vpc_id" {}
+
+variable "ip_whitelist" {
+  type    = list(string)
+  default = []
+}

--- a/k8s/clusters/eks/us-west-2/locals.tf
+++ b/k8s/clusters/eks/us-west-2/locals.tf
@@ -24,14 +24,15 @@ locals {
   }
 
   mdn_node_groups = {
-    default_ng = {
-      desired_capacity = "10"
-      min_capacity     = "10"
-      max_capacity     = "20"
-      disk_size        = "100"
-      instance_type    = "m5.xlarge"
-      key_name         = "mdn"
-      subnets          = data.terraform_remote_state.vpc-us-west-2.outputs.private_subnets
+    default_ng_1 = {
+      desired_capacity          = "10"
+      min_capacity              = "10"
+      max_capacity              = "20"
+      disk_size                 = "100"
+      instance_type             = "m5.xlarge"
+      key_name                  = "mdn"
+      source_security_group_ids = [module.ssh_sg.ssh_security_group_id]
+      subnets                   = data.terraform_remote_state.vpc-us-west-2.outputs.public_subnets
 
       k8s_label = {
         Service = "default"
@@ -39,7 +40,7 @@ locals {
       }
 
       additional_tags = {
-        "Name"                              = "mdn-default-ng"
+        "Name"                              = "mdn-default-ng-1"
         "kubernetes.io/cluster/mdn"         = "owned"
         "k8s.io/cluster-autoscaler/enabled" = "true"
       }
@@ -56,13 +57,6 @@ locals {
       username = "maws-mdn-admin"
       rolearn  = "arn:aws:iam::178589013767:role/maws-mdn-admin"
       groups   = ["system:masters"]
-    },
-    {
-      username = "AdminRole"
-      # This is a bug in k8s, the role in IAM will not match this
-      # file since k8s has issues parsing roles with paths
-      rolearn = "arn:aws:iam::178589013767:role/AdminRole"
-      groups  = ["system:masters"]
     },
     {
       username = "jenkins"

--- a/k8s/clusters/eks/us-west-2/main.tf
+++ b/k8s/clusters/eks/us-west-2/main.tf
@@ -14,34 +14,6 @@ module "mdn-jenkins-rbac" {
   }
 }
 
-resource "aws_security_group" "ssh" {
-  name        = "eks-allow-ssh"
-  description = "Allow inbound SSH"
-  vpc_id      = data.terraform_remote_state.vpc-us-west-2.outputs.vpc_id
-
-  ingress {
-    from_port = "22"
-    to_port   = "22"
-    protocol  = "tcp"
-    cidr_blocks = [
-      data.aws_vpc.us-west-2.cidr_block
-    ]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = {
-    Name      = "eks-allow-ssh-sg"
-    Terraform = "true"
-    Region    = var.region
-  }
-}
-
 module "ssh_sg" {
   source = "../modules/security-groups"
   region = var.region

--- a/k8s/clusters/eks/us-west-2/main.tf
+++ b/k8s/clusters/eks/us-west-2/main.tf
@@ -14,6 +14,40 @@ module "mdn-jenkins-rbac" {
   }
 }
 
+resource "aws_security_group" "ssh" {
+  name        = "eks-allow-ssh"
+  description = "Allow inbound SSH"
+  vpc_id      = data.terraform_remote_state.vpc-us-west-2.outputs.vpc_id
+
+  ingress {
+    from_port = "22"
+    to_port   = "22"
+    protocol  = "tcp"
+    cidr_blocks = [
+      data.aws_vpc.us-west-2.cidr_block
+    ]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name      = "eks-allow-ssh-sg"
+    Terraform = "true"
+    Region    = var.region
+  }
+}
+
+module "ssh_sg" {
+  source = "../modules/security-groups"
+  region = var.region
+  vpc_id = data.terraform_remote_state.vpc-us-west-2.outputs.vpc_id
+}
+
 module "mdn" {
   source = "github.com/mozilla-it/terraform-modules//aws/eks?ref=master"
 

--- a/k8s/clusters/eks/us-west-2/outputs.tf
+++ b/k8s/clusters/eks/us-west-2/outputs.tf
@@ -34,6 +34,10 @@ output "mdn_cluster_primary_security_group_id" {
   value = module.mdn.cluster_primary_security_group_id
 }
 
+output "mdn_worker_security_group_id" {
+  value = module.mdn.worker_security_group_id
+}
+
 output "mdn_cluster_oidc_issuer_url" {
   value = module.mdn.cluster_oidc_issuer_url
 }


### PR DESCRIPTION
Make changes to prep EKS cutover, worker node groups are now running on public subnet with public IPs on each nodes. Opened up ssh access as well for debugging purposes