### PR TITLE
update primary cloudfront behaviors

### DIFF
--- a/apps/mdn/mdn-aws/infra/modules/mdn-cdn/cloudfront_primary/README.md
+++ b/apps/mdn/mdn-aws/infra/modules/mdn-cdn/cloudfront_primary/README.md
@@ -1,4 +1,5 @@
 # MDN Primary CDN
+
 This CDN configuration is used to create the CDN placed in front of
 [developer.mozilla.org](https://developer.mozilla.org) (production) as well as
 the CDN in front of [developer.allizom.org](https://developer.allizom.org)
@@ -11,42 +12,40 @@ compression, but GZip only (Brotli compression is not yet supported).
 CloudFront will
 [cache many error responses by default](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/HTTPStatusCodes.html#HTTPStatusCodes-cached-errors),
 so we include custom error responses that effectively turn-off the caching for:
-* `400 Bad Request`
-* `403 Forbidden`
-* `404 Not Found`
-* `500 Internal Server Error`
-* `502 Bad Gateway`
-* `504 Gateway Timeout`
+
+- `400 Bad Request`
+- `403 Forbidden`
+- `404 Not Found`
+- `500 Internal Server Error`
+- `502 Bad Gateway`
+- `504 Gateway Timeout`
 
 CloudFront ignores the `Vary` header. All desired cache variance must be
 explicitly configured via the header, cookie, and query-parameter configuration
 within each behavior.
 
 ## Static and Media Behaviors
+
 The first three behaviors (`#0`, `#1`, and `#2`) match against requests for static
 and media files. The responses to these requests are cached for long periods of time
 (typically a year or more). These behaviors eliminate the need for a
 separate CDN for the static/media assets.
 
+## Core Document Behavior
+
+Behavior `#3` handles the core requests to MDN, the document requests.
+
 ## Pass-Through Behaviors
-Each of these behaviors, `#3` through `#14` as well as `#19` through `#26`, share
-the same configuration except for the path pattern, and are designed to simply
-forward the complete incoming request to the origin (all headers, cookies,
-and query parameters), and perform **no** caching of the response. Most,
-if not all, of these behaviors match endpoints that allow `POST` requests that
-depend upon a `csrftoken` cookie, which is so varied as to make caching
-useless anyway. Also, most of these behaviors match endpoints that require
-login, so not caching them is of almost no consequence since requests
+
+The next eight behaviors, `#4` through `#11`, share the same configuration except for the path pattern, and are designed to simply forward the complete incoming request to the origin (all headers, cookies, and query parameters), and perform **no** caching of the response. For example, some of these behaviors match endpoints that allow `POST` requests that depend upon a `csrftoken` cookie, which is so varied as to make caching useless. Also, many of these behaviors match endpoints that require login, so not caching them is of almost no consequence since requests
 from logged-in users comprise only a tiny fraction of the total requests.
 
-## Dashboard Caching Behaviors
-Behaviors `#16`, `#17`, and `#18`, are designed specifically for the three
-dashboard endpoints that can vary caching based on the `X-Requested-With`
-header.
+## S3-Related Behaviors
 
-## Core Document Behavior
-Behavior `#15` handles the core requests to MDN, the document requests.
+Behaviors `#12`, `#13`, `#15` and `#16` all foward their requests to the S3 media
+bucket.
 
 ## Default Behavior
+
 The default behavior handles all requests that do not match any of the
 preceding behaviors.

--- a/apps/mdn/mdn-aws/infra/modules/mdn-cdn/cloudfront_primary/main.tf
+++ b/apps/mdn/mdn-aws/infra/modules/mdn-cdn/cloudfront_primary/main.tf
@@ -249,7 +249,7 @@ resource "aws_cloudfront_distribution" "mdn-primary-cf-dist" {
 
   # 6
   ordered_cache_behavior {
-    path_pattern = "*/profile/*"
+    path_pattern = "*/profile"
 
     allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
     cached_methods         = ["GET", "HEAD"]
@@ -273,7 +273,7 @@ resource "aws_cloudfront_distribution" "mdn-primary-cf-dist" {
 
   # 7
   ordered_cache_behavior {
-    path_pattern = "*/profiles/*"
+    path_pattern = "*/profile/*"
 
     allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
     cached_methods         = ["GET", "HEAD"]
@@ -296,6 +296,30 @@ resource "aws_cloudfront_distribution" "mdn-primary-cf-dist" {
   }
 
   # 8
+  ordered_cache_behavior {
+    path_pattern = "*/profiles/*"
+
+    allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    min_ttl                = 0
+    smooth_streaming       = false
+    target_origin_id       = var.distribution_name
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = true
+      headers      = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  # 9
   ordered_cache_behavior {
     path_pattern = "*/payments/*"
 
@@ -320,7 +344,7 @@ resource "aws_cloudfront_distribution" "mdn-primary-cf-dist" {
   }
 
 
-  # 9
+  # 10
   ordered_cache_behavior {
     path_pattern = "admin/*"
 
@@ -340,29 +364,6 @@ resource "aws_cloudfront_distribution" "mdn-primary-cf-dist" {
 
       cookies {
         forward = "all"
-      }
-    }
-  }
-
-  # 10
-  ordered_cache_behavior {
-    path_pattern = "api/v1/doc/*"
-
-    allowed_methods        = ["GET", "HEAD"]
-    cached_methods         = ["GET", "HEAD"]
-    compress               = true
-    default_ttl            = 3600
-    max_ttl                = 3600
-    min_ttl                = 3600
-    smooth_streaming       = false
-    target_origin_id       = var.distribution_name
-    viewer_protocol_policy = "redirect-to-https"
-
-    forwarded_values {
-      query_string = false
-
-      cookies {
-        forward = "none"
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/mdn/kuma/issues/7415

This PR does 3 things:
- adds an additional CF behavior `*/profile` to fix https://github.com/mdn/kuma/issues/7415
- removes the `api/v1/doc/*` behavior (since that endpoint has not existed for some time)
- updates the CDN `README`