### PR TITLE
Setup redirect for mozilla.dev

### DIFF
--- a/k8s/services/redirector/redirector.conf
+++ b/k8s/services/redirector/redirector.conf
@@ -1,9 +1,14 @@
 server {
+    server_name mozilla.dev;
+    return 301 https://developer.mozilla.org;
+}
+
+server {
     server_name www.mozilla.dev;
-    return 301 https://mozilla.dev$request_uri;
+    return 301 https://developer.mozilla.org;
 }
 
 server {
     server_name developer.mozilla.com;
-    return 301 https://mozilla.dev$request_uri;
+    return 301 https://developer.mozilla.org;
 }


### PR DESCRIPTION
Sets up redirect for mozilla.dev -> developer.mozilla.org

RIP