### PR TITLE
add stage and prod yari alt domains for testing

### DIFF
--- a/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.sh
@@ -49,7 +49,7 @@ export WEB_CPU_LIMIT=4
 export WEB_CPU_REQUEST=500m
 export WEB_MEMORY_LIMIT=6Gi
 export WEB_MEMORY_REQUEST=4Gi
-export WEB_ALLOWED_HOSTS="developer.mozilla.org,wiki.developer.mozilla.org,mdn.mozillademos.org,demos.mdn.mozit.cloud,demos-origin.mdn.mozit.cloud,developer-prod.mdn.mozit.cloud,prod.mdn.mozit.cloud"
+export WEB_ALLOWED_HOSTS="developer.mozilla.org,wiki.developer.mozilla.org,mdn.mozillademos.org,demos.mdn.mozit.cloud,demos-origin.mdn.mozit.cloud,developer-prod.mdn.mozit.cloud,prod.mdn.mozit.cloud,yari.prod.mdn.mozit.cloud"
 
 export API_NAME=api
 export API_REPLICAS=4

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/prod.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/prod.sh
@@ -49,7 +49,7 @@ export WEB_CPU_LIMIT=4
 export WEB_CPU_REQUEST=500m
 export WEB_MEMORY_LIMIT=6Gi
 export WEB_MEMORY_REQUEST=4Gi
-export WEB_ALLOWED_HOSTS="developer.mozilla.org,wiki.developer.mozilla.org,mdn.mozillademos.org,demos.mdn.mozit.cloud,demos-origin.mdn.mozit.cloud,developer-prod.mdn.mozit.cloud,prod.mdn.mozit.cloud"
+export WEB_ALLOWED_HOSTS="developer.mozilla.org,wiki.developer.mozilla.org,mdn.mozillademos.org,demos.mdn.mozit.cloud,demos-origin.mdn.mozit.cloud,developer-prod.mdn.mozit.cloud,prod.mdn.mozit.cloud,yari.prod.mdn.mozit.cloud"
 
 export API_NAME=api
 export API_REPLICAS=4

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/stage.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/stage.mm.sh
@@ -49,7 +49,7 @@ export WEB_CPU_LIMIT=2
 export WEB_CPU_REQUEST=100m
 export WEB_MEMORY_LIMIT=6Gi
 export WEB_MEMORY_REQUEST=4Gi
-export WEB_ALLOWED_HOSTS="developer.allizom.org,wiki.developer.allizom.org,developer-stage.mdn.mozit.cloud,stage.mdn.mozit.cloud,files-stage.mdn.mozit.cloud"
+export WEB_ALLOWED_HOSTS="developer.allizom.org,wiki.developer.allizom.org,developer-stage.mdn.mozit.cloud,stage.mdn.mozit.cloud,files-stage.mdn.mozit.cloud,yari.stage.mdn.mozit.cloud"
 
 export API_NAME=api
 export API_REPLICAS=1

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
@@ -49,7 +49,7 @@ export WEB_CPU_LIMIT=2
 export WEB_CPU_REQUEST=100m
 export WEB_MEMORY_LIMIT=6Gi
 export WEB_MEMORY_REQUEST=4Gi
-export WEB_ALLOWED_HOSTS="developer.allizom.org,wiki.developer.allizom.org,developer-stage.mdn.mozit.cloud,stage.mdn.mozit.cloud,files-stage.mdn.mozit.cloud"
+export WEB_ALLOWED_HOSTS="developer.allizom.org,wiki.developer.allizom.org,developer-stage.mdn.mozit.cloud,stage.mdn.mozit.cloud,files-stage.mdn.mozit.cloud,yari.stage.mdn.mozit.cloud"
 
 export API_NAME=api
 export API_REPLICAS=1


### PR DESCRIPTION
Add the `yari.stage.mdn.mozit.cloud` and `yari.prod.mdn.mozit.cloud` domains to the `WEB_ALLOWED_HOSTS` setting for stage and prod. This is for testing the new stage and prod CDN's for Yari.