### PR TITLE
Redirect beta and wiki to developer.mozilla.org

### DIFF
--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -212,7 +212,7 @@ export REDIRECTOR_NAMESPACE ?= "redirector"
 export REDIRECTOR_REPLICAS ?= 1
 export REDIRECTOR_MAX_REPLICAS ?= 4
 export REDIRECTOR_IMAGE_NAME ?= mdnwebdocs/redirector
-export REDIRECTOR_IMAGE_TAG ?= 5dc4a49
+export REDIRECTOR_IMAGE_TAG ?= 3c86c15
 export REDIRECTOR_SERVICE_PORT ?= 80
 export REDIRECTOR_CONTAINER_PORT ?= 80
 # This list must be without quotes

--- a/apps/mdn/mdn-aws/k8s/Makefile
+++ b/apps/mdn/mdn-aws/k8s/Makefile
@@ -216,7 +216,7 @@ export REDIRECTOR_IMAGE_TAG ?= 5dc4a49
 export REDIRECTOR_SERVICE_PORT ?= 80
 export REDIRECTOR_CONTAINER_PORT ?= 80
 # This list must be without quotes
-export REDIRECTOR_HOSTS ?= mozilla.dev,www.mozilla.dev,developer.mozilla.com
+export REDIRECTOR_HOSTS ?= mozilla.dev,www.mozilla.dev,developer.mozilla.com,beta.developer.mozilla.org,wiki.developer.mozilla.org
 
 ###############################
 ### core tasks

--- a/k8s/clusters/modules/nginx-ingress/main.tf
+++ b/k8s/clusters/modules/nginx-ingress/main.tf
@@ -1,9 +1,9 @@
 
 locals {
 
-  ingress_nginx_repository = "https://kubernetes-charts.storage.googleapis.com"
+  ingress_nginx_repository = "https://kubernetes.github.io/ingress-nginx"
   ingress_class            = var.environment == "" ? "nginx" : "nginx-${var.environment}"
-  ingress_name             = var.name == "" ? "nginx-ingress" : var.name
+  ingress_name             = var.name == "" ? "ingress-nginx" : var.name
   ingress_namespace        = var.namespace == "" ? "kube-system" : var.namespace
 
   ingress_nginx_settings_defaults = {
@@ -31,7 +31,7 @@ resource "helm_release" "ingress_nginx" {
   count      = var.enabled ? 1 : 0
   name       = local.ingress_name
   repository = local.ingress_nginx_repository
-  chart      = "nginx-ingress"
+  chart      = "ingress-nginx"
   namespace  = local.ingress_namespace
 
   dynamic "set" {

--- a/k8s/clusters/us-west-2/providers.tf
+++ b/k8s/clusters/us-west-2/providers.tf
@@ -1,10 +1,8 @@
 provider "aws" {
-  version = "~> 2"
-  region  = var.region
+  region = var.region
 }
 
 provider "local" {
-  version = "~> 1.2"
 }
 
 provider "kubernetes" {
@@ -16,8 +14,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  version = "~> 1"
-  alias   = "mdn"
+  alias = "mdn"
 
   kubernetes {
     host                   = data.aws_eks_cluster.mdn.endpoint

--- a/k8s/clusters/us-west-2/versions.tf
+++ b/k8s/clusters/us-west-2/versions.tf
@@ -1,4 +1,18 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    helm = {
+      source = "hashicorp/helm"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+  }
 }

--- a/k8s/services/redirector/redirector.conf
+++ b/k8s/services/redirector/redirector.conf
@@ -12,3 +12,13 @@ server {
     server_name developer.mozilla.com;
     return 301 https://developer.mozilla.org;
 }
+
+server {
+    server_name wiki.developer.mozilla.org;
+    return 301 https://developer.mozilla.org$request_uri;
+}
+
+server {
+    server_name beta.developer.mozilla.org;
+    return 301 https://developer.mozilla.org$request_uri;
+}


### PR DESCRIPTION
This PR is primarily for redirecting `wiki.developer.mozilla.org` and `beta.developer.mozilla.org` to `developer.mozilla.org` 

However I'm sneaking in some terraform since there is some changes to the naming convention of some helm charts