### PR TITLE
adjust untrusted origin for yari

### DIFF
--- a/apps/mdn/mdn-aws/k8s/regions/germany/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/germany/prod.mm.sh
@@ -49,7 +49,7 @@ export WEB_CPU_LIMIT=4
 export WEB_CPU_REQUEST=500m
 export WEB_MEMORY_LIMIT=6Gi
 export WEB_MEMORY_REQUEST=4Gi
-export WEB_ALLOWED_HOSTS="developer.mozilla.org,wiki.developer.mozilla.org,mdn.mozillademos.org,demos.mdn.mozit.cloud,demos-origin.mdn.mozit.cloud,developer-prod.mdn.mozit.cloud,prod.mdn.mozit.cloud,standby.mdn.mozit.cloud"
+export WEB_ALLOWED_HOSTS="developer.mozilla.org,mdn.mozillademos.org,demos.mdn.mozit.cloud,demos-origin.mdn.mozit.cloud,developer-prod.mdn.mozit.cloud,prod.mdn.mozit.cloud,standby.mdn.mozit.cloud,yari-demos.prod.mdn.mozit.cloud"
 
 export API_NAME=api
 export API_REPLICAS=1
@@ -107,7 +107,7 @@ export KUMA_ADMIN_NAMES="MDN devs"
 export KUMA_ALLOW_ROBOTS=True
 export KUMA_API_S3_BUCKET_NAME=mdn-api-prod
 export KUMA_ATTACHMENT_HOST=mdn.mozillademos.org
-export KUMA_ATTACHMENT_ORIGIN=demos-origin.mdn.mozit.cloud
+export KUMA_ATTACHMENT_ORIGIN=yari-demos.prod.mdn.mozit.cloud
 export KUMA_ATTACHMENTS_AWS_STORAGE_BUCKET_NAME="mdn-media-prod"
 export KUMA_ATTACHMENTS_AWS_S3_REGION_NAME="us-west-2"
 export KUMA_ATTACHMENTS_AWS_S3_CUSTOM_DOMAIN="media.prod.mdn.mozit.cloud"

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.sh
@@ -49,7 +49,7 @@ export WEB_CPU_LIMIT=4
 export WEB_CPU_REQUEST=500m
 export WEB_MEMORY_LIMIT=6Gi
 export WEB_MEMORY_REQUEST=4Gi
-export WEB_ALLOWED_HOSTS="developer.mozilla.org,wiki.developer.mozilla.org,mdn.mozillademos.org,demos.mdn.mozit.cloud,demos-origin.mdn.mozit.cloud,developer-prod.mdn.mozit.cloud,prod.mdn.mozit.cloud"
+export WEB_ALLOWED_HOSTS="developer.mozilla.org,mdn.mozillademos.org,demos.mdn.mozit.cloud,demos-origin.mdn.mozit.cloud,developer-prod.mdn.mozit.cloud,prod.mdn.mozit.cloud,yari-demos.prod.mdn.mozit.cloud"
 
 export API_NAME=api
 export API_REPLICAS=4
@@ -107,7 +107,7 @@ export KUMA_ADMIN_NAMES="MDN devs"
 export KUMA_ALLOW_ROBOTS=True
 export KUMA_API_S3_BUCKET_NAME=mdn-api-prod
 export KUMA_ATTACHMENT_HOST=mdn.mozillademos.org
-export KUMA_ATTACHMENT_ORIGIN=demos-origin.mdn.mozit.cloud
+export KUMA_ATTACHMENT_ORIGIN=yari-demos.prod.mdn.mozit.cloud
 export KUMA_ATTACHMENTS_AWS_STORAGE_BUCKET_NAME="mdn-media-prod"
 export KUMA_ATTACHMENTS_AWS_S3_REGION_NAME="us-west-2"
 export KUMA_ATTACHMENTS_AWS_S3_CUSTOM_DOMAIN="media.prod.mdn.mozit.cloud"

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/prod.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/prod.sh
@@ -49,7 +49,7 @@ export WEB_CPU_LIMIT=4
 export WEB_CPU_REQUEST=500m
 export WEB_MEMORY_LIMIT=6Gi
 export WEB_MEMORY_REQUEST=4Gi
-export WEB_ALLOWED_HOSTS="developer.mozilla.org,wiki.developer.mozilla.org,mdn.mozillademos.org,demos.mdn.mozit.cloud,demos-origin.mdn.mozit.cloud,developer-prod.mdn.mozit.cloud,prod.mdn.mozit.cloud"
+export WEB_ALLOWED_HOSTS="developer.mozilla.org,mdn.mozillademos.org,demos.mdn.mozit.cloud,demos-origin.mdn.mozit.cloud,developer-prod.mdn.mozit.cloud,prod.mdn.mozit.cloud,yari-demos.prod.mdn.mozit.cloud"
 
 export API_NAME=api
 export API_REPLICAS=4
@@ -107,7 +107,7 @@ export KUMA_ADMIN_NAMES="MDN devs"
 export KUMA_ALLOW_ROBOTS=True
 export KUMA_API_S3_BUCKET_NAME=mdn-api-prod
 export KUMA_ATTACHMENT_HOST=mdn.mozillademos.org
-export KUMA_ATTACHMENT_ORIGIN=demos-origin.mdn.mozit.cloud
+export KUMA_ATTACHMENT_ORIGIN=yari-demos.prod.mdn.mozit.cloud
 export KUMA_ATTACHMENTS_AWS_STORAGE_BUCKET_NAME="mdn-media-prod"
 export KUMA_ATTACHMENTS_AWS_S3_REGION_NAME="us-west-2"
 export KUMA_ATTACHMENTS_AWS_S3_CUSTOM_DOMAIN="media.prod.mdn.mozit.cloud"

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/stage.mm.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/stage.mm.sh
@@ -49,7 +49,7 @@ export WEB_CPU_LIMIT=2
 export WEB_CPU_REQUEST=100m
 export WEB_MEMORY_LIMIT=6Gi
 export WEB_MEMORY_REQUEST=4Gi
-export WEB_ALLOWED_HOSTS="developer.allizom.org,wiki.developer.allizom.org,developer-stage.mdn.mozit.cloud,stage.mdn.mozit.cloud,files-stage.mdn.mozit.cloud"
+export WEB_ALLOWED_HOSTS="developer.allizom.org,developer-stage.mdn.mozit.cloud,stage.mdn.mozit.cloud,files-stage.mdn.mozit.cloud,yari-demos.stage.mdn.mozit.cloud"
 
 export API_NAME=api
 export API_REPLICAS=1
@@ -107,7 +107,7 @@ export KUMA_ADMIN_NAMES="MDN devs"
 export KUMA_ALLOW_ROBOTS=False
 export KUMA_API_S3_BUCKET_NAME=mdn-api-stage
 export KUMA_ATTACHMENT_HOST=files-stage.mdn.mozit.cloud
-export KUMA_ATTACHMENT_ORIGIN=files-stage.mdn.mozit.cloud
+export KUMA_ATTACHMENT_ORIGIN=yari-demos.stage.mdn.mozit.cloud
 export KUMA_ATTACHMENTS_AWS_STORAGE_BUCKET_NAME="mdn-media-stage"
 export KUMA_ATTACHMENTS_AWS_S3_REGION_NAME="us-west-2"
 export KUMA_ATTACHMENTS_AWS_S3_CUSTOM_DOMAIN="media.stage.mdn.mozit.cloud"

--- a/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
+++ b/apps/mdn/mdn-aws/k8s/regions/oregon/stage.sh
@@ -49,7 +49,7 @@ export WEB_CPU_LIMIT=2
 export WEB_CPU_REQUEST=100m
 export WEB_MEMORY_LIMIT=6Gi
 export WEB_MEMORY_REQUEST=4Gi
-export WEB_ALLOWED_HOSTS="developer.allizom.org,wiki.developer.allizom.org,developer-stage.mdn.mozit.cloud,stage.mdn.mozit.cloud,files-stage.mdn.mozit.cloud"
+export WEB_ALLOWED_HOSTS="developer.allizom.org,developer-stage.mdn.mozit.cloud,stage.mdn.mozit.cloud,files-stage.mdn.mozit.cloud,yari-demos.stage.mdn.mozit.cloud"
 
 export API_NAME=api
 export API_REPLICAS=1
@@ -107,7 +107,7 @@ export KUMA_ADMIN_NAMES="MDN devs"
 export KUMA_ALLOW_ROBOTS=False
 export KUMA_API_S3_BUCKET_NAME=mdn-api-stage
 export KUMA_ATTACHMENT_HOST=files-stage.mdn.mozit.cloud
-export KUMA_ATTACHMENT_ORIGIN=files-stage.mdn.mozit.cloud
+export KUMA_ATTACHMENT_ORIGIN=yari-demos.stage.mdn.mozit.cloud
 export KUMA_ATTACHMENTS_AWS_STORAGE_BUCKET_NAME="mdn-media-stage"
 export KUMA_ATTACHMENTS_AWS_S3_REGION_NAME="us-west-2"
 export KUMA_ATTACHMENTS_AWS_S3_CUSTOM_DOMAIN="media.stage.mdn.mozit.cloud"


### PR DESCRIPTION
When this is deployed, it fixes https://github.com/mdn/yari/issues/2331 until the file attachment flaws can be fixed to follow the new "Yari" approach which doesn't rely on Kuma and the file attachment-related tables in MySQL.