### PR TITLE
update node runtime to version 12

### DIFF
--- a/apps/mdn/mdn-dev/modules/cdn/main.tf
+++ b/apps/mdn/mdn-dev/modules/cdn/main.tf
@@ -190,7 +190,7 @@ resource "aws_lambda_function" "lambda-headers" {
   source_code_hash = data.archive_file.lambda-zip.output_base64sha256
   role             = aws_iam_role.lambda-edge-role.arn
   handler          = var.event_trigger
-  runtime          = "nodejs10.x"
+  runtime          = "nodejs12.x"
 
   tags = {
     Name        = "${var.servicename}-headers"
@@ -198,4 +198,3 @@ resource "aws_lambda_function" "lambda-headers" {
     Terraform   = "true"
   }
 }
-


### PR DESCRIPTION
AWS is ending support of the Node.js 10 runtime in Lambdas on August 30, 2021 (see https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html).