### PR TITLE
downsize EKS clusters

### DIFF
--- a/k8s/clusters/eu-central-1/locals.tf
+++ b/k8s/clusters/eu-central-1/locals.tf
@@ -10,8 +10,8 @@ locals {
 
   mdn_node_groups = {
     default_ng_1 = {
-      desired_capacity          = "3"
-      min_capacity              = "3"
+      desired_capacity          = "2"
+      min_capacity              = "2"
       max_capacity              = "12"
       disk_size                 = "50"
       instance_type             = "m5.large"

--- a/k8s/clusters/us-west-2/locals.tf
+++ b/k8s/clusters/us-west-2/locals.tf
@@ -9,9 +9,9 @@ locals {
 
   mdn_node_groups = {
     default_ng = {
-      desired_capacity = "8"
-      min_capacity     = "8"
-      max_capacity     = "20"
+      desired_capacity = "4"
+      min_capacity     = "4"
+      max_capacity     = "12"
       disk_size        = "100"
       instance_type    = "m5.xlarge"
       subnets          = data.terraform_remote_state.vpc-us-west-2.outputs.public_subnets
@@ -52,4 +52,3 @@ locals {
     Terraform = "true"
   }
 }
-


### PR DESCRIPTION
Now that we've collapsed Kuma and removed the `api`, `kumascript`, and `ssr` services, deployments, and HPA's, downsize the `us-west-2` and `eu-central-1` EKS clusters.