### PR TITLE
ssh-tunnel remove limed keys

### DIFF
--- a/apps/mdn/ssh-tunnel/main.tf
+++ b/apps/mdn/ssh-tunnel/main.tf
@@ -7,7 +7,6 @@ module "ssh_tunnel_eu_central_1" {
   zone_id    = data.terraform_remote_state.dns.outputs.us-west-2-zone-id
 
   github_users = [
-    "limed",
     "escattone",
     "peterbe",
     "schalkneethling"

--- a/apps/mdn/ssh-tunnel/modules/ssh-tunnel/variables.tf
+++ b/apps/mdn/ssh-tunnel/modules/ssh-tunnel/variables.tf
@@ -20,7 +20,7 @@ variable "ssh_pubkey" {
 
 variable "github_users" {
   type    = list(string)
-  default = ["limed", "escattone", "Gregoor", "peterbe", "tobinmori", "schalkneethling"]
+  default = ["escattone", "peterbe", "schalkneethling"]
 }
 
 variable "zone_id" {}


### PR DESCRIPTION
This pulls from public github keys. Removed limed and a couple users from the default vars (these are overwritten by the main.tf call). I tried to find the other users in the directory but could not. Once confirmed I will rotate the ssh tunnel instance to remove keys.