### PR TITLE
SE-2281 Clean up mdn-aws-infra

### DIFF
--- a/apps/mdn/mdn-aws/infra/locals.tf
+++ b/apps/mdn/mdn-aws/infra/locals.tf
@@ -2,7 +2,7 @@ locals {
 
   rds_defaults_defaults = {
     username              = "root"
-    engine_version        = "5.6.41"
+    engine_version        = "5.6.51"
     backup_retention_days = "1"
     storage_type          = "gp2"
     storage_gb            = "100"

--- a/apps/mdn/mdn-aws/infra/main.tf
+++ b/apps/mdn/mdn-aws/infra/main.tf
@@ -120,11 +120,13 @@ module "mysql-us-west-2" {
   mysql_engine_version        = local.rds["stage"]["engine_version"]
   mysql_instance_class        = local.rds["stage"]["instance_class"]
   mysql_backup_retention_days = local.rds["stage"]["backup_retention_days"]
-  mysql_security_group_name   = "mdn_rds_sg_stage"
   mysql_storage_gb            = local.rds["stage"]["storage_gb"]
   mysql_storage_type          = local.rds["stage"]["storage_type"]
-  vpc_id                      = data.terraform_remote_state.vpc-us-west-2.outputs.vpc_id
-  monitoring_interval         = "60"
+  # This security group is also used for Postgres which is not in terraform yet.
+  # Do not delete this security group
+  rds_security_group_name = "mdn_rds_sg_stage"
+  vpc_id                  = data.terraform_remote_state.vpc-us-west-2.outputs.vpc_id
+  monitoring_interval     = "60"
 }
 
 module "mysql-us-west-2-prod" {
@@ -140,11 +142,13 @@ module "mysql-us-west-2-prod" {
   mysql_engine_version        = local.rds["prod"]["engine_version"]
   mysql_instance_class        = local.rds["prod"]["instance_class"]
   mysql_backup_retention_days = local.rds["prod"]["backup_retention_days"]
-  mysql_security_group_name   = "mdn_rds_sg_prod"
   mysql_storage_gb            = local.rds["prod"]["storage_gb"]
   mysql_storage_type          = local.rds["prod"]["storage_type"]
-  vpc_id                      = data.terraform_remote_state.vpc-us-west-2.outputs.vpc_id
-  monitoring_interval         = "60"
+  # This security group is also used for Postgres which is not in terraform yet.
+  # Do not delete this security group
+  rds_security_group_name = "mdn_rds_sg_prod"
+  vpc_id                  = data.terraform_remote_state.vpc-us-west-2.outputs.vpc_id
+  monitoring_interval     = "60"
 }
 
 # Replica set

--- a/apps/mdn/mdn-aws/infra/modules/media-sync/outputs.tf
+++ b/apps/mdn/mdn-aws/infra/modules/media-sync/outputs.tf
@@ -1,7 +1,7 @@
 output "role_arn" {
-  value = module.iam_assumable_role.this_iam_role_arn
+  value = module.iam_assumable_role.iam_role_arn
 }
 
 output "role_name" {
-  value = module.iam_assumable_role.this_iam_role_name
+  value = module.iam_assumable_role.iam_role_name
 }

--- a/apps/mdn/mdn-aws/infra/modules/multi_region/rds-replica/inputs.tf
+++ b/apps/mdn/mdn-aws/infra/modules/multi_region/rds-replica/inputs.tf
@@ -41,6 +41,10 @@ variable "mysql_port" {
   default = "3306"
 }
 
+variable "postgres_port" {
+  default = 5432
+}
+
 variable "monitoring_interval" {
   default = "0"
 }

--- a/apps/mdn/mdn-aws/infra/modules/multi_region/rds-replica/main.tf
+++ b/apps/mdn/mdn-aws/infra/modules/multi_region/rds-replica/main.tf
@@ -64,6 +64,13 @@ resource "aws_security_group" "replica-sg" {
     cidr_blocks = [data.aws_vpc.vpc_cidr.cidr_block]
   }
 
+  ingress {
+    from_port   = var.postgres_port
+    to_port     = var.postgres_port
+    protocol    = "TCP"
+    cidr_blocks = [data.aws_vpc.vpc_cidr.cidr_block]
+  }
+
   egress {
     from_port   = 0
     to_port     = 0

--- a/apps/mdn/mdn-aws/infra/modules/multi_region/rds/main.tf
+++ b/apps/mdn/mdn-aws/infra/modules/multi_region/rds/main.tf
@@ -84,13 +84,20 @@ resource "aws_db_instance" "mdn_rds" {
 
 resource "aws_security_group" "mdn_rds_sg" {
   count       = var.enabled ? 1 : 0
-  name        = var.mysql_security_group_name
+  name        = var.rds_security_group_name
   description = "Allow all inbound traffic"
   vpc_id      = var.vpc_id
 
   ingress {
     from_port   = var.mysql_port
     to_port     = var.mysql_port
+    protocol    = "TCP"
+    cidr_blocks = [data.aws_vpc.id.cidr_block]
+  }
+
+  ingress {
+    from_port   = var.postgres_port
+    to_port     = var.postgres_port
     protocol    = "TCP"
     cidr_blocks = [data.aws_vpc.id.cidr_block]
   }

--- a/apps/mdn/mdn-aws/infra/modules/multi_region/rds/variables.tf
+++ b/apps/mdn/mdn-aws/infra/modules/multi_region/rds/variables.tf
@@ -21,7 +21,7 @@ variable "mysql_identifier" {
 variable "mysql_env" {
 }
 
-variable "mysql_security_group_name" {
+variable "rds_security_group_name" {
 }
 
 variable "mysql_storage_gb" {
@@ -36,6 +36,11 @@ variable "mysql_instance_class" {
 
 variable "mysql_port" {
   default     = 3306
+  description = "ingress port to open"
+}
+
+variable "postgres_port" {
+  default     = 5432
   description = "ingress port to open"
 }
 

--- a/apps/mdn/mdn-aws/infra/modules/rds-backups/outputs.tf
+++ b/apps/mdn/mdn-aws/infra/modules/rds-backups/outputs.tf
@@ -3,9 +3,9 @@ output "rds-backup-bucket-name" {
 }
 
 output "rds_backup_role_arn" {
-  value = module.iam_assumable_role_admin.this_iam_role_arn
+  value = module.iam_assumable_role_admin.iam_role_arn
 }
 
 output "rds_backup_role_name" {
-  value = module.iam_assumable_role_admin.this_iam_role_name
+  value = module.iam_assumable_role_admin.iam_role_name
 }

--- a/apps/mdn/mdn-aws/infra/modules/security/outputs.tf
+++ b/apps/mdn/mdn-aws/infra/modules/security/outputs.tf
@@ -1,7 +1,7 @@
 output "worf_role_name" {
-  value = module.iam_assumable_role_admin.this_iam_role_name
+  value = module.iam_assumable_role_admin.iam_role_name
 }
 
 output "worf_role_arn" {
-  value = module.iam_assumable_role_admin.this_iam_role_arn
+  value = module.iam_assumable_role_admin.iam_role_arn
 }


### PR DESCRIPTION
Small changes to get a clean plan in mdn-aws/infra. Some slight manual tweaks to mysql version and security groups. Setting up a variable here to be used for all rds databases instead of only mysql.

Terraform plan as follows:
```bash                                                    
No changes. Infrastructure is up-to-date.                                                                                      
                                                               
This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no                                  
actions need to be performed. 
```