### PR TITLE
SE-2413 ssh tunnel access

### DIFF
--- a/apps/mdn/ssh-tunnel/main.tf
+++ b/apps/mdn/ssh-tunnel/main.tf
@@ -8,6 +8,14 @@ module "ssh_tunnel_eu_central_1" {
   github_users = [
     "escattone",
     "peterbe",
-    "schalkneethling"
+    "schalkneethling",
+    # Web SRE Team
+    # According to https://github.com/orgs/mozilla-it/teams/it-se/members?query=membership:child-team
+    "bkochendorfer",
+    "duallain",
+    "floatingatoll",
+    "sciurus",
+    "smarnach",
+    "cmharlow"
   ]
 }


### PR DESCRIPTION
This gives the web sre team access to ssh into the MDN VPC. I'd like to get this rolled out and https://github.com/mdn/ansible-jenkins/pull/18 in before I rotate the Jenkins host. That way we can troubleshoot if needed on the host itself.