### PR TITLE
SE-2280 Decom mysql

### DIFF
--- a/apps/mdn/mdn-aws/infra/main.tf
+++ b/apps/mdn/mdn-aws/infra/main.tf
@@ -113,18 +113,6 @@ module "mysql-us-west-2" {
   environment = "stage"
   region      = "us-west-2"
 
-  # mysql database
-  mysql_env                   = "stage"
-  mysql_db_name               = local.rds["stage"]["db_name"]
-  mysql_username              = local.rds["stage"]["username"]
-  mysql_password              = var.rds["stage"]["password"]
-  mysql_identifier            = "mdn-stage"
-  mysql_engine_version        = local.rds["stage"]["engine_version"]
-  mysql_instance_class        = local.rds["stage"]["instance_class"]
-  mysql_backup_retention_days = local.rds["stage"]["backup_retention_days"]
-  mysql_storage_gb            = local.rds["stage"]["storage_gb"]
-  mysql_storage_type          = local.rds["stage"]["storage_type"]
-
   # postgres database
   postgres_db_name               = local.rds["stage"]["db_name"]
   postgres_username              = local.rds["stage"]["postgres_username"]
@@ -148,18 +136,6 @@ module "mysql-us-west-2-prod" {
   environment = "prod"
   region      = "us-west-2"
 
-  # mysql database
-  mysql_env                   = "prod"
-  mysql_db_name               = local.rds["prod"]["db_name"]
-  mysql_username              = local.rds["prod"]["username"]
-  mysql_password              = var.rds["prod"]["password"]
-  mysql_identifier            = "mdn-prod"
-  mysql_engine_version        = local.rds["prod"]["engine_version"]
-  mysql_instance_class        = local.rds["prod"]["instance_class"]
-  mysql_backup_retention_days = local.rds["prod"]["backup_retention_days"]
-  mysql_storage_gb            = local.rds["prod"]["storage_gb"]
-  mysql_storage_type          = local.rds["prod"]["storage_type"]
-
   # postgres database
   postgres_db_name               = local.rds["prod"]["db_name"]
   postgres_username              = local.rds["prod"]["postgres_username"]
@@ -181,7 +157,6 @@ module "mysql-eu-central-1-replica-prod" {
   source                     = "./modules/multi_region/rds-replica"
   environment                = "prod"
   region                     = "eu-central-1"
-  replica_source_db          = module.mysql-us-west-2-prod.rds_arn
   postgres_replica_source_db = module.mysql-us-west-2-prod.postgres_rds_arn
   vpc_id                     = data.terraform_remote_state.vpc-eu-central-1.outputs.vpc_id
   kms_key_id                 = lookup(var.rds, "key_id.eu-central-1") # Less than ideal this key is copied from the console

--- a/apps/mdn/mdn-aws/infra/modules/multi_region/rds-replica/inputs.tf
+++ b/apps/mdn/mdn-aws/infra/modules/multi_region/rds-replica/inputs.tf
@@ -20,9 +20,6 @@ variable "storage_type" {
   default = "gp2"
 }
 
-variable "replica_source_db" {
-}
-
 variable "subnet_type" {
   default = "Public"
 }
@@ -35,10 +32,6 @@ variable "vpc_id" {
 
 variable "multi_az" {
   default = true
-}
-
-variable "mysql_port" {
-  default = "3306"
 }
 
 variable "postgres_port" {

--- a/apps/mdn/mdn-aws/infra/modules/multi_region/rds-replica/main.tf
+++ b/apps/mdn/mdn-aws/infra/modules/multi_region/rds-replica/main.tf
@@ -32,26 +32,6 @@ resource "aws_db_subnet_group" "replica" {
   tags        = merge({ "Name" = "${local.name_prefix}-subnet-group" }, local.tags)
 }
 
-resource "aws_db_instance" "replica" {
-  count = var.enabled ? 1 : 0
-
-  identifier           = local.name_prefix
-  replicate_source_db  = var.replica_source_db
-  instance_class       = var.instance_class
-  storage_type         = var.storage_type
-  kms_key_id           = var.kms_key_id
-  storage_encrypted    = true
-  db_subnet_group_name = aws_db_subnet_group.replica.name
-
-  vpc_security_group_ids = [aws_security_group.replica-sg[0].id]
-  multi_az               = var.multi_az
-
-  apply_immediately   = true
-  skip_final_snapshot = true
-  monitoring_interval = var.monitoring_interval
-  tags                = merge({ "Name" = local.name_prefix }, local.tags)
-}
-
 resource "aws_db_instance" "postgres_replica" {
   count = var.enabled ? 1 : 0
 
@@ -78,13 +58,6 @@ resource "aws_security_group" "replica-sg" {
   name  = "${local.name_prefix}-sg"
 
   vpc_id = var.vpc_id
-
-  ingress {
-    from_port   = var.mysql_port
-    to_port     = var.mysql_port
-    protocol    = "TCP"
-    cidr_blocks = [data.aws_vpc.vpc_cidr.cidr_block]
-  }
 
   ingress {
     from_port   = var.postgres_port

--- a/apps/mdn/mdn-aws/infra/modules/multi_region/rds-replica/outputs.tf
+++ b/apps/mdn/mdn-aws/infra/modules/multi_region/rds-replica/outputs.tf
@@ -1,4 +1,3 @@
-output "replica_rds_id" {
-  value = element(concat(aws_db_instance.replica.*.id, [""]), 0)
+output "postgres_replica_rds_id" {
+  value = element(concat(aws_db_instance.postgres_replica.*.id, [""]), 0)
 }
-

--- a/apps/mdn/mdn-aws/infra/modules/multi_region/rds/main.tf
+++ b/apps/mdn/mdn-aws/infra/modules/multi_region/rds/main.tf
@@ -23,63 +23,12 @@ locals {
   }
 }
 
-resource "aws_db_parameter_group" "mdn-params" {
-  count = var.enabled ? 1 : 0
-
-  name        = "${var.mysql_identifier}-params"
-  family      = "mysql5.6"
-  description = "Paramter group for ${var.mysql_identifier}"
-
-  # https://stackoverflow.com/questions/8744813/mysql-error-2006-hy000-at-line-406-mysql-server-has-gone-away#10709964
-  parameter {
-    name  = "max_allowed_packet"
-    value = "26214400"
-  }
-}
-
 resource "aws_db_subnet_group" "rds" {
   count       = var.enabled ? 1 : 0
   name        = "mdn-${var.environment}-rds-subnet-group"
   description = "mdn-${var.environment}-rds-subnet-group"
   subnet_ids  = data.aws_subnet_ids.this.ids
   tags        = merge({ "Name" = "mdn-${var.environment}-rds-subnet-group" }, local.tags)
-}
-
-resource "aws_db_instance" "mdn_rds" {
-  count = var.enabled ? 1 : 0
-
-  allocated_storage           = var.mysql_storage_gb
-  allow_major_version_upgrade = var.mysql_allow_major_version_upgrade
-  auto_minor_version_upgrade  = var.mysql_auto_minor_version_upgrade
-  backup_retention_period     = var.mysql_backup_retention_days
-  backup_window               = var.mysql_backup_window
-
-  # note: this resource already existed at time of provisioning from
-  # our k8s install automation
-  #db_subnet_group_name        = "main_subnet_group"
-  db_subnet_group_name = element(aws_db_subnet_group.rds.*.name, count.index)
-
-  depends_on = [aws_security_group.mdn_rds_sg]
-  engine     = var.mysql_engine
-
-  engine_version               = var.mysql_engine_version
-  identifier                   = var.mysql_identifier
-  instance_class               = var.mysql_instance_class
-  maintenance_window           = var.mysql_maintenance_window
-  multi_az                     = true
-  name                         = var.mysql_db_name
-  parameter_group_name         = aws_db_parameter_group.mdn-params[0].name
-  password                     = var.mysql_password
-  publicly_accessible          = false
-  storage_encrypted            = var.mysql_storage_encrypted
-  storage_type                 = var.mysql_storage_type
-  username                     = var.mysql_username
-  vpc_security_group_ids       = [aws_security_group.mdn_rds_sg[0].id]
-  skip_final_snapshot          = true
-  apply_immediately            = true
-  monitoring_interval          = var.monitoring_interval
-  performance_insights_enabled = var.performance_insights_enabled
-  tags                         = merge({ "Name" = "MDN-rds-${var.environment}" }, local.tags)
 }
 
 resource "aws_db_instance" "mdn_postgres" {
@@ -125,13 +74,6 @@ resource "aws_security_group" "mdn_rds_sg" {
   name        = var.rds_security_group_name
   description = "Allow all inbound traffic"
   vpc_id      = var.vpc_id
-
-  ingress {
-    from_port   = var.mysql_port
-    to_port     = var.mysql_port
-    protocol    = "TCP"
-    cidr_blocks = [data.aws_vpc.id.cidr_block]
-  }
 
   ingress {
     from_port   = var.postgres_port

--- a/apps/mdn/mdn-aws/infra/modules/multi_region/rds/outputs.tf
+++ b/apps/mdn/mdn-aws/infra/modules/multi_region/rds/outputs.tf
@@ -1,19 +1,15 @@
-output "rds_arn" {
-  value = element(concat(aws_db_instance.mdn_rds.*.arn, [""]), 0)
-}
-
-output "rds_address" {
-  value = element(concat(aws_db_instance.mdn_rds.*.address, [""]), 0)
-}
-
-output "rds_endpoint" {
-  value = element(concat(aws_db_instance.mdn_rds.*.endpoint, [""]), 0)
-}
-
-output "rds_id" {
-  value = element(concat(aws_db_instance.mdn_rds.*.id, [""]), 0)
-}
-
 output "postgres_rds_arn" {
   value = element(concat(aws_db_instance.mdn_postgres.*.arn, [""]), 0)
+}
+
+output "postgres_rds_address" {
+  value = element(concat(aws_db_instance.mdn_postgres.*.address, [""]), 0)
+}
+
+output "postgres_rds_endpoint" {
+  value = element(concat(aws_db_instance.mdn_postgres.*.endpoint, [""]), 0)
+}
+
+output "postgres_rds_id" {
+  value = element(concat(aws_db_instance.mdn_postgres.*.id, [""]), 0)
 }

--- a/apps/mdn/mdn-aws/infra/modules/multi_region/rds/variables.tf
+++ b/apps/mdn/mdn-aws/infra/modules/multi_region/rds/variables.tf
@@ -6,80 +6,12 @@ variable "enabled" {
   default = true
 }
 
-variable "mysql_db_name" {
-}
-
-variable "mysql_username" {
-}
-
-variable "mysql_password" {
-}
-
-variable "mysql_identifier" {
-}
-
-variable "mysql_env" {
-}
-
 variable "rds_security_group_name" {
-}
-
-variable "mysql_storage_gb" {
-  default     = "100"
-  description = "Storage size in GB"
-}
-
-variable "mysql_instance_class" {
-  default     = "db.m3.xlarge"
-  description = "Instance class"
-}
-
-variable "mysql_port" {
-  default     = 3306
-  description = "ingress port to open"
 }
 
 variable "postgres_port" {
   default     = 5432
   description = "ingress port to open"
-}
-
-variable "mysql_engine" {
-  default     = "mysql"
-  description = "Engine type, example values mysql, postgres"
-}
-
-variable "mysql_engine_version" {
-  description = "Engine version"
-  default     = "5.6.35"
-}
-
-variable "mysql_storage_type" {
-  default = "gp2"
-}
-
-variable "mysql_backup_retention_days" {
-  default = 7
-}
-
-variable "mysql_backup_window" {
-  default = "00:00-00:30"
-}
-
-variable "mysql_maintenance_window" {
-  default = "Sun:00:31-Sun:01:01"
-}
-
-variable "mysql_storage_encrypted" {
-  default = true
-}
-
-variable "mysql_auto_minor_version_upgrade" {
-  default = true
-}
-
-variable "mysql_allow_major_version_upgrade" {
-  default = false
 }
 
 variable "postgres_storage_gb" {

--- a/apps/mdn/mdn-aws/infra/outputs.tf
+++ b/apps/mdn/mdn-aws/infra/outputs.tf
@@ -10,8 +10,8 @@ output "us-west-2-redis-stage-endpoint" {
   value = module.redis-stage-us-west-2.redis_endpoint
 }
 
-output "us-west-2-rds-endpoint" {
-  value = module.mysql-us-west-2.rds_endpoint
+output "us-west-2-postgres-rds-endpoint" {
+  value = module.mysql-us-west-2.postgres_rds_endpoint
 }
 
 output "ci_acm_arn" {


### PR DESCRIPTION
We are moving away from Mysql to Postgres. We have backups of the mysql databases and they can now be decommed.

```bash
  # module.mysql-eu-central-1-replica-prod.aws_db_instance.replica[0] will be destroyed
  - resource "aws_db_instance" "replica" {
      - address                               = "mdn-prod-replica.cdnr0ilttchi.eu-central-1.rds.amazonaws.com" -> null
      - allocated_storage                     = 200 -> null
      - apply_immediately                     = true -> null
      - arn                                   = "arn:aws:rds:eu-central-1:178589013767:db:mdn-prod-replica" -> null
      - auto_minor_version_upgrade            = true -> null
      - availability_zone                     = "eu-central-1b" -> null
      - backup_retention_period               = 0 -> null
      - backup_window                         = "00:00-00:30" -> null
      - ca_cert_identifier                    = "rds-ca-2019" -> null
      - copy_tags_to_snapshot                 = false -> null
      - db_subnet_group_name                  = "mdn-prod-replica-subnet-group" -> null
      - delete_automated_backups              = true -> null
      - deletion_protection                   = false -> null
      - enabled_cloudwatch_logs_exports       = [] -> null
      - endpoint                              = "mdn-prod-replica.cdnr0ilttchi.eu-central-1.rds.amazonaws.com:3306" -> null
      - engine                                = "mysql" -> null
      - engine_version                        = "5.6.51" -> null
      - hosted_zone_id                        = "Z1RLNUO7B9Q6NB" -> null
      - iam_database_authentication_enabled   = false -> null
      - id                                    = "mdn-prod-replica" -> null
      - identifier                            = "mdn-prod-replica" -> null
      - instance_class                        = "db.m5.xlarge" -> null
      - iops                                  = 0 -> null
      - kms_key_id                            = "arn:aws:kms:eu-central-1:178589013767:key/d825fec7-2f43-4010-b91f-782876263bb8" -> null
      - latest_restorable_time                = "0001-01-01T00:00:00Z" -> null
      - license_model                         = "general-public-license" -> null
      - maintenance_window                    = "sun:00:31-sun:01:01" -> null
      - max_allocated_storage                 = 0 -> null
      - monitoring_interval                   = 60 -> null
      - monitoring_role_arn                   = "arn:aws:iam::178589013767:role/rds-monitoring-role" -> null
      - multi_az                              = true -> null
      - name                                  = "developer_mozilla_org" -> null
      - option_group_name                     = "default:mysql-5-6" -> null
      - parameter_group_name                  = "default.mysql5.6" -> null
      - performance_insights_enabled          = false -> null
      - performance_insights_retention_period = 0 -> null
      - port                                  = 3306 -> null
      - publicly_accessible                   = false -> null
      - replicas                              = [] -> null
      - replicate_source_db                   = "arn:aws:rds:us-west-2:178589013767:db:mdn-prod" -> null
      - resource_id                           = "db-A6YOMVWAT4XH5GSDMF3CXBFV4A" -> null
      - security_group_names                  = [] -> null
      - skip_final_snapshot                   = true -> null
      - status                                = "available" -> null
      - storage_encrypted                     = true -> null
      - storage_type                          = "gp2" -> null
      - tags                                  = {
          - "Environment" = "prod"
          - "Name"        = "mdn-prod-replica"
          - "Region"      = "eu-central-1"
          - "Service"     = "MDN"
          - "Terraform"   = "true"
        } -> null
      - tags_all                              = {
          - "Environment" = "prod"
          - "Name"        = "mdn-prod-replica"
          - "Region"      = "eu-central-1"
          - "Service"     = "MDN"
          - "Terraform"   = "true"
        } -> null
      - username                              = "root" -> null
      - vpc_security_group_ids                = [
          - "sg-0a3c4a1e571399d66",
        ] -> null

      - timeouts {}
    }

  # module.mysql-eu-central-1-replica-prod.aws_security_group.replica-sg[0] will be updated in-place
  ~ resource "aws_security_group" "replica-sg" {
        id                     = "sg-0a3c4a1e571399d66"
      ~ ingress                = [
          - {
              - cidr_blocks      = [
                  - "172.20.0.0/16",
                ]
              - description      = ""
              - from_port        = 3306
              - ipv6_cidr_blocks = []
              - prefix_list_ids  = []
              - protocol         = "TCP"
              - security_groups  = []
              - self             = false
              - to_port          = 3306
            },
          - {
              - cidr_blocks      = [
                  - "172.20.0.0/16",
                ]
              - description      = ""
              - from_port        = 5432
              - ipv6_cidr_blocks = []
              - prefix_list_ids  = []
              - protocol         = "tcp"
              - security_groups  = []
              - self             = false
              - to_port          = 5432
            },
          + {
              + cidr_blocks      = [
                  + "172.20.0.0/16",
                ]
              + description      = null
              + from_port        = 5432
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 5432
            },
        ]
        name                   = "mdn-prod-replica-sg"
        tags                   = {
            "Environment" = "prod"
            "Name"        = "mdn-prod-replica-sg"
            "Region"      = "eu-central-1"
            "Service"     = "MDN"
            "Terraform"   = "true"
        }
        # (7 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

  # module.mysql-us-west-2.aws_db_instance.mdn_rds[0] will be destroyed
  - resource "aws_db_instance" "mdn_rds" {
      - address                               = "mdn-stage.cvd5ntsxtv8p.us-west-2.rds.amazonaws.com" -> null
      - allocated_storage                     = 100 -> null
      - allow_major_version_upgrade           = false -> null
      - apply_immediately                     = true -> null
      - arn                                   = "arn:aws:rds:us-west-2:178589013767:db:mdn-stage" -> null
      - auto_minor_version_upgrade            = true -> null
      - availability_zone                     = "us-west-2c" -> null
      - backup_retention_period               = 1 -> null
      - backup_window                         = "00:00-00:30" -> null
      - ca_cert_identifier                    = "rds-ca-2019" -> null
      - copy_tags_to_snapshot                 = false -> null
      - db_subnet_group_name                  = "mdn-stage-rds-subnet-group" -> null
      - delete_automated_backups              = true -> null
      - deletion_protection                   = false -> null
      - enabled_cloudwatch_logs_exports       = [] -> null
      - endpoint                              = "mdn-stage.cvd5ntsxtv8p.us-west-2.rds.amazonaws.com:3306" -> null
      - engine                                = "mysql" -> null
      - engine_version                        = "5.6.51" -> null
      - hosted_zone_id                        = "Z1PVIF0B656C1W" -> null
      - iam_database_authentication_enabled   = false -> null
      - id                                    = "mdn-stage" -> null
      - identifier                            = "mdn-stage" -> null
      - instance_class                        = "db.t3.large" -> null
      - iops                                  = 0 -> null
      - kms_key_id                            = "arn:aws:kms:us-west-2:178589013767:key/e82d0945-5e72-4917-9e28-881304555fea" -> null
      - latest_restorable_time                = "2021-08-09T19:50:00Z" -> null
      - license_model                         = "general-public-license" -> null
      - maintenance_window                    = "sun:00:31-sun:01:01" -> null
      - max_allocated_storage                 = 0 -> null
      - monitoring_interval                   = 60 -> null
      - monitoring_role_arn                   = "arn:aws:iam::178589013767:role/rds-monitoring-role" -> null
      - multi_az                              = true -> null
      - name                                  = "developer_allizom_org" -> null
      - option_group_name                     = "default:mysql-5-6" -> null
      - parameter_group_name                  = "mdn-stage-params" -> null
      - password                              = (sensitive value)
      - performance_insights_enabled          = true -> null
      - performance_insights_kms_key_id       = "arn:aws:kms:us-west-2:178589013767:key/e82d0945-5e72-4917-9e28-881304555fea" -> null
      - performance_insights_retention_period = 0 -> null
      - port                                  = 3306 -> null
      - publicly_accessible                   = false -> null
      - replicas                              = [] -> null
      - resource_id                           = "db-W4J2P5M452VWI2IZS7FVD2YZ2Q" -> null
      - security_group_names                  = [] -> null
      - skip_final_snapshot                   = true -> null
      - status                                = "stopped" -> null
      - storage_encrypted                     = true -> null
      - storage_type                          = "gp2" -> null
      - tags                                  = {
          - "Environment" = "stage"
          - "Name"        = "MDN-rds-stage"
          - "Region"      = "us-west-2"
          - "Service"     = "MDN"
          - "Terraform"   = "true"
        } -> null
      - tags_all                              = {
          - "Environment" = "stage"
          - "Name"        = "MDN-rds-stage"
          - "Region"      = "us-west-2"
          - "Service"     = "MDN"
          - "Terraform"   = "true"
        } -> null
      - username                              = "root" -> null
      - vpc_security_group_ids                = [
          - "sg-e5ce2496",
        ] -> null

      - timeouts {}
    }

  # module.mysql-us-west-2.aws_db_parameter_group.mdn-params[0] will be destroyed
  - resource "aws_db_parameter_group" "mdn-params" {
      - arn         = "arn:aws:rds:us-west-2:178589013767:pg:mdn-stage-params" -> null
      - description = "Paramter group for mdn-stage" -> null
      - family      = "mysql5.6" -> null
      - id          = "mdn-stage-params" -> null
      - name        = "mdn-stage-params" -> null
      - tags        = {} -> null
      - tags_all    = {} -> null

      - parameter {
          - apply_method = "immediate" -> null
          - name         = "max_allowed_packet" -> null
          - value        = "26214400" -> null
        }
    }

  # module.mysql-us-west-2.aws_security_group.mdn_rds_sg[0] will be updated in-place
  ~ resource "aws_security_group" "mdn_rds_sg" {
        id                     = "sg-e5ce2496"
      ~ ingress                = [
          - {
              - cidr_blocks      = [
                  - "172.20.0.0/16",
                ]
              - description      = ""
              - from_port        = 3306
              - ipv6_cidr_blocks = []
              - prefix_list_ids  = []
              - protocol         = "TCP"
              - security_groups  = []
              - self             = false
              - to_port          = 3306
            },
          - {
              - cidr_blocks      = [
                  - "172.20.0.0/16",
                ]
              - description      = ""
              - from_port        = 5432
              - ipv6_cidr_blocks = []
              - prefix_list_ids  = []
              - protocol         = "tcp"
              - security_groups  = []
              - self             = false
              - to_port          = 5432
            },
          + {
              + cidr_blocks      = [
                  + "172.20.0.0/16",
                ]
              + description      = null
              + from_port        = 5432
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 5432
            },
        ]
        name                   = "mdn_rds_sg_stage"
        tags                   = {
            "Environment" = "stage"
            "Name"        = "mdn_rds_sg-stage"
            "Region"      = "us-west-2"
            "Service"     = "MDN"
            "Terraform"   = "true"
        }
        # (7 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

  # module.mysql-us-west-2-prod.aws_db_instance.mdn_rds[0] will be destroyed
  - resource "aws_db_instance" "mdn_rds" {
      - address                               = "mdn-prod.cvd5ntsxtv8p.us-west-2.rds.amazonaws.com" -> null
      - allocated_storage                     = 200 -> null
      - allow_major_version_upgrade           = false -> null
      - apply_immediately                     = true -> null
      - arn                                   = "arn:aws:rds:us-west-2:178589013767:db:mdn-prod" -> null
      - auto_minor_version_upgrade            = true -> null
      - availability_zone                     = "us-west-2a" -> null
      - backup_retention_period               = 7 -> null
      - backup_window                         = "00:00-00:30" -> null
      - ca_cert_identifier                    = "rds-ca-2019" -> null
      - copy_tags_to_snapshot                 = false -> null
      - db_subnet_group_name                  = "mdn-prod-rds-subnet-group" -> null
      - delete_automated_backups              = true -> null
      - deletion_protection                   = false -> null
      - enabled_cloudwatch_logs_exports       = [] -> null
      - endpoint                              = "mdn-prod.cvd5ntsxtv8p.us-west-2.rds.amazonaws.com:3306" -> null
      - engine                                = "mysql" -> null
      - engine_version                        = "5.6.51" -> null
      - hosted_zone_id                        = "Z1PVIF0B656C1W" -> null
      - iam_database_authentication_enabled   = false -> null
      - id                                    = "mdn-prod" -> null
      - identifier                            = "mdn-prod" -> null
      - instance_class                        = "db.m5.xlarge" -> null
      - iops                                  = 0 -> null
      - kms_key_id                            = "arn:aws:kms:us-west-2:178589013767:key/e82d0945-5e72-4917-9e28-881304555fea" -> null
      - latest_restorable_time                = "2021-08-10T19:45:00Z" -> null
      - license_model                         = "general-public-license" -> null
      - maintenance_window                    = "sun:00:31-sun:01:01" -> null
      - max_allocated_storage                 = 0 -> null
      - monitoring_interval                   = 60 -> null
      - monitoring_role_arn                   = "arn:aws:iam::178589013767:role/rds-monitoring-role" -> null
      - multi_az                              = true -> null
      - name                                  = "developer_mozilla_org" -> null
      - option_group_name                     = "default:mysql-5-6" -> null
      - parameter_group_name                  = "mdn-prod-params" -> null
      - password                              = (sensitive value)
      - performance_insights_enabled          = true -> null
      - performance_insights_kms_key_id       = "arn:aws:kms:us-west-2:178589013767:key/e82d0945-5e72-4917-9e28-881304555fea" -> null
      - performance_insights_retention_period = 0 -> null
      - port                                  = 3306 -> null
      - publicly_accessible                   = false -> null
      - replicas                              = [
          - "mdn-prod-replica",
          - "arn:aws:rds:eu-central-1:178589013767:db:mdn-prod-replica",
        ] -> null
      - resource_id                           = "db-65GMQ6N3JMIWWHSHHWQDB6J4YU" -> null
      - security_group_names                  = [] -> null
      - skip_final_snapshot                   = true -> null
      - status                                = "available" -> null
      - storage_encrypted                     = true -> null
      - storage_type                          = "gp2" -> null
      - tags                                  = {
          - "Environment" = "prod"
          - "Name"        = "MDN-rds-prod"
          - "Region"      = "us-west-2"
          - "Service"     = "MDN"
          - "Terraform"   = "true"
        } -> null
      - tags_all                              = {
          - "Environment" = "prod"
          - "Name"        = "MDN-rds-prod"
          - "Region"      = "us-west-2"
          - "Service"     = "MDN"
          - "Terraform"   = "true"
        } -> null
      - username                              = "root" -> null
      - vpc_security_group_ids                = [
          - "sg-05582650bc1475423",
        ] -> null

      - timeouts {}
    }

  # module.mysql-us-west-2-prod.aws_db_parameter_group.mdn-params[0] will be destroyed
  - resource "aws_db_parameter_group" "mdn-params" {
      - arn         = "arn:aws:rds:us-west-2:178589013767:pg:mdn-prod-params" -> null
      - description = "Paramter group for mdn-prod" -> null
      - family      = "mysql5.6" -> null
      - id          = "mdn-prod-params" -> null
      - name        = "mdn-prod-params" -> null
      - tags        = {} -> null
      - tags_all    = {} -> null

      - parameter {
          - apply_method = "immediate" -> null
          - name         = "max_allowed_packet" -> null
          - value        = "26214400" -> null
        }
    }

  # module.mysql-us-west-2-prod.aws_security_group.mdn_rds_sg[0] will be updated in-place
  ~ resource "aws_security_group" "mdn_rds_sg" {
        id                     = "sg-05582650bc1475423"
      ~ ingress                = [
          - {
              - cidr_blocks      = [
                  - "172.20.0.0/16",
                ]
              - description      = ""
              - from_port        = 3306
              - ipv6_cidr_blocks = []
              - prefix_list_ids  = []
              - protocol         = "TCP"
              - security_groups  = []
              - self             = false
              - to_port          = 3306
            },
          - {
              - cidr_blocks      = [
                  - "172.20.0.0/16",
                ]
              - description      = ""
              - from_port        = 5432
              - ipv6_cidr_blocks = []
              - prefix_list_ids  = []
              - protocol         = "tcp"
              - security_groups  = []
              - self             = false
              - to_port          = 5432
            },
          + {
              + cidr_blocks      = [
                  + "172.20.0.0/16",
                ]
              + description      = null
              + from_port        = 5432
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 5432
            },
        ]
        name                   = "mdn_rds_sg_prod"
        tags                   = {
            "Environment" = "prod"
            "Name"        = "mdn_rds_sg-prod"
            "Region"      = "us-west-2"
            "Service"     = "MDN"
            "Terraform"   = "true"
        }
        # (7 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 3 to change, 5 to destroy.

Changes to Outputs:
  + us-west-2-postgres-rds-endpoint = "mdn-stage-postgres.cvd5ntsxtv8p.us-west-2.rds.amazonaws.com:5432"
  - us-west-2-rds-endpoint          = "mdn-stage.cvd5ntsxtv8p.us-west-2.rds.amazonaws.com:3306" -> null

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.
```
