### PR TITLE
SE-2442 Updates cloudfront distribution for production.

### DIFF
--- a/apps/mdn/mdn-aws/infra/acm.tf
+++ b/apps/mdn/mdn-aws/infra/acm.tf
@@ -29,10 +29,19 @@ data "aws_acm_certificate" "prod-media-cdn-cert" {
   domain   = "media.prod.mdn.mozit.cloud"
 }
 
-# Update certificate for stage
+# SE-2442
+# Updates certificate for stage
 # Created via ClickOps as the main domain lives in infoblox
 data "aws_acm_certificate" "updates_stage_mdn_mozit_cloud" {
   provider = aws.acm
   domain   = "updates.developer.allizom.org"
+}
+
+# SE-2442
+# Updates certificate for prod
+# Created via ClickOps as the main domain lives in infoblox
+data "aws_acm_certificate" "updates_prod_mdn_mozit_cloud" {
+  provider = aws.acm
+  domain   = "updates.developer.mozilla.org"
 }
 

--- a/apps/mdn/mdn-aws/infra/main.tf
+++ b/apps/mdn/mdn-aws/infra/main.tf
@@ -68,6 +68,14 @@ module "mdn_updates_stage" {
   acm_cert_arn = data.aws_acm_certificate.updates_stage_mdn_mozit_cloud.arn
 }
 
+# SE-2442 create updates infrastructure
+module "mdn_updates_prod" {
+  source       = "./modules/mdn-updates"
+  region       = var.region
+  environment  = "prod"
+  acm_cert_arn = data.aws_acm_certificate.updates_prod_mdn_mozit_cloud.arn
+}
+
 # TODO: Split this up into multiple files other stuff can get messy quick
 # Multi region resources
 

--- a/apps/mdn/mdn-aws/infra/modules/mdn-updates/main.tf
+++ b/apps/mdn/mdn-aws/infra/modules/mdn-updates/main.tf
@@ -164,7 +164,7 @@ resource "aws_cloudfront_distribution" "updates_distribution" {
     custom_origin_config {
       http_port                = "80"
       https_port               = "443"
-      origin_protocol_policy   = "http-only"
+      origin_protocol_policy   = "https-only"
       origin_read_timeout      = 30
       origin_ssl_protocols     = ["TLSv1.2"]
       origin_keepalive_timeout = 5


### PR DESCRIPTION
* Uses the module for updates infrastructure.
* Adds a new cache policy to include the origin in the cache key

```bash
form will perform the following actions:

  # module.mdn_updates_prod.data.aws_iam_policy_document.public_read will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "public_read"  {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions   = [
              + "s3:GetObject",
            ]
          + effect    = "Allow"
          + resources = [
              + (known after apply),
            ]

          + principals {
              + identifiers = [
                  + "*",
                ]
              + type        = "*"
            }
        }
    }

  # module.mdn_updates_prod.aws_cloudfront_cache_policy.cache_policy_one_year_origin_header will be created
  + resource "aws_cloudfront_cache_policy" "cache_policy_one_year_origin_header" {
      + comment     = "This is the same as MDN-Yearlong-Caching but includes the Origin Header in the Cache key"
      + default_ttl = 31536000
      + etag        = (known after apply)
      + id          = (known after apply)
      + max_ttl     = 31536000
      + min_ttl     = 31536000
      + name        = "MDN-Yearlong-Caching-Origin-Header"

      + parameters_in_cache_key_and_forwarded_to_origin {
          + enable_accept_encoding_brotli = true
          + enable_accept_encoding_gzip   = true

          + cookies_config {
              + cookie_behavior = "none"
            }

          + headers_config {
              + header_behavior = "whitelist"

              + headers {
                  + items = [
                      + "Origin",
                    ]
                }
            }

          + query_strings_config {
              + query_string_behavior = "none"
            }
        }
    }

  # module.mdn_updates_prod.aws_cloudfront_distribution.updates_distribution will be created
  + resource "aws_cloudfront_distribution" "updates_distribution" {
      + aliases                        = [
          + "updates.developer.mozilla.org",
          + "updates.prod.mdn.mozit.cloud",
        ]
      + arn                            = (known after apply)
      + caller_reference               = (known after apply)
      + comment                        = "MDN prod Updates CDN"
      + domain_name                    = (known after apply)
      + enabled                        = true
      + etag                           = (known after apply)
      + hosted_zone_id                 = (known after apply)
      + http_version                   = "http2"
      + id                             = (known after apply)
      + in_progress_validation_batches = (known after apply)
      + is_ipv6_enabled                = false
      + last_modified_time             = (known after apply)
      + price_class                    = "PriceClass_All"
      + retain_on_delete               = false
      + status                         = (known after apply)
      + tags                           = {
          + "Purpose"   = "MDN prod Updates CDN"
          + "Service"   = "MDN"
          + "Terraform" = "true"
        }
      + tags_all                       = {
          + "Purpose"   = "MDN prod Updates CDN"
          + "Service"   = "MDN"
          + "Terraform" = "true"
        }
      + trusted_key_groups             = (known after apply)
      + trusted_signers                = (known after apply)
      + wait_for_deployment            = true

      + default_cache_behavior {
          + allowed_methods          = [
              + "GET",
              + "HEAD",
              + "OPTIONS",
            ]
          + cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
          + cached_methods           = [
              + "GET",
              + "HEAD",
            ]
          + compress                 = false
          + default_ttl              = (known after apply)
          + max_ttl                  = (known after apply)
          + min_ttl                  = 0
          + origin_request_policy_id = "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf"
          + target_origin_id         = (known after apply)
          + trusted_key_groups       = (known after apply)
          + trusted_signers          = (known after apply)
          + viewer_protocol_policy   = "redirect-to-https"
        }

      + ordered_cache_behavior {
          + allowed_methods          = [
              + "GET",
              + "HEAD",
              + "OPTIONS",
            ]
          + cache_policy_id          = (known after apply)
          + cached_methods           = [
              + "GET",
              + "HEAD",
            ]
          + compress                 = true
          + default_ttl              = (known after apply)
          + max_ttl                  = (known after apply)
          + min_ttl                  = 0
          + origin_request_policy_id = "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf"
          + path_pattern             = "/packages/*"
          + target_origin_id         = (known after apply)
          + viewer_protocol_policy   = "redirect-to-https"
        }

      + origin {
          + connection_attempts = 3
          + connection_timeout  = 10
          + domain_name         = (known after apply)
          + origin_id           = (known after apply)

          + custom_origin_config {
              + http_port                = 80
              + https_port               = 443
              + origin_keepalive_timeout = 5
              + origin_protocol_policy   = "http-only"
              + origin_read_timeout      = 30
              + origin_ssl_protocols     = [
                  + "TLSv1.2",
                ]
            }
        }

      + restrictions {
          + geo_restriction {
              + locations        = (known after apply)
              + restriction_type = "none"
            }
        }

      + viewer_certificate {
          + acm_certificate_arn      = "..removed.."
          + minimum_protocol_version = "TLSv1"
          + ssl_support_method       = "sni-only"
        }
    }

  # module.mdn_updates_prod.aws_iam_user.updates_user will be created
  + resource "aws_iam_user" "updates_user" {
      + arn           = (known after apply)
      + force_destroy = false
      + id            = (known after apply)
      + name          = (known after apply)
      + path          = "/itsre/"
      + tags          = (known after apply)
      + tags_all      = (known after apply)
      + unique_id     = (known after apply)
    }

  # module.mdn_updates_prod.aws_iam_user_policy.updates_user will be created
  + resource "aws_iam_user_policy" "updates_user" {
      + id     = (known after apply)
      + name   = (known after apply)
      + policy = (known after apply)
      + user   = (known after apply)
    }

  # module.mdn_updates_prod.aws_s3_bucket.updates_bucket will be created
  + resource "aws_s3_bucket" "updates_bucket" {
      + acceleration_status         = (known after apply)
      + acl                         = "public-read"
      + arn                         = (known after apply)
      + bucket                      = (known after apply)
      + bucket_domain_name          = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + policy                      = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags                        = (known after apply)
      + tags_all                    = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + cors_rule {
          + allowed_headers = [
              + "*",
            ]
          + allowed_methods = [
              + "GET",
              + "HEAD",
            ]
          + allowed_origins = [
              + "*",
            ]
          + expose_headers  = [
              + "ETag",
            ]
          + max_age_seconds = 3000
        }

      + lifecycle_rule {
          + enabled = true
          + id      = (known after apply)

          + expiration {
              + days = 90
            }
        }

      + versioning {
          + enabled    = true
          + mfa_delete = false
        }

      + website {
          + error_document = "404.html"
          + index_document = "index.html"
        }
    }

  # module.mdn_updates_prod.random_id.rand_var will be created
  + resource "random_id" "rand_var" {
      + b64_std     = (known after apply)
      + b64_url     = (known after apply)
      + byte_length = 8
      + dec         = (known after apply)
      + hex         = (known after apply)
      + id          = (known after apply)
      + keepers     = {
          + "bucket_name" = "updates-prod-developer-mozilla"
        }
    }

  # module.mdn_updates_stage.aws_cloudfront_cache_policy.cache_policy_one_year_origin_header will be created
  + resource "aws_cloudfront_cache_policy" "cache_policy_one_year_origin_header" {
      + comment     = "This is the same as MDN-Yearlong-Caching but includes the Origin Header in the Cache key"
      + default_ttl = 31536000
      + etag        = (known after apply)
      + id          = (known after apply)
      + max_ttl     = 31536000
      + min_ttl     = 31536000
      + name        = "MDN-Yearlong-Caching-Origin-Header"

      + parameters_in_cache_key_and_forwarded_to_origin {
          + enable_accept_encoding_brotli = true
          + enable_accept_encoding_gzip   = true

          + cookies_config {
              + cookie_behavior = "none"
            }

          + headers_config {
              + header_behavior = "whitelist"

              + headers {
                  + items = [
                      + "Origin",
                    ]
                }
            }

          + query_strings_config {
              + query_string_behavior = "none"
            }
        }
    }

  # module.mdn_updates_stage.aws_cloudfront_distribution.updates_distribution will be updated in-place
  ~ resource "aws_cloudfront_distribution" "updates_distribution" {
        id                             = "ETH17RXARRPY8"
        tags                           = {
            "Purpose"   = "MDN stage Updates CDN"
            "Service"   = "MDN"
            "Terraform" = "true"
        }
        # (19 unchanged attributes hidden)


      ~ ordered_cache_behavior {
          ~ cache_policy_id          = "1c436a21-6535-40c6-ae57-0aa9e2d0c51b" -> (known after apply)
            # (13 unchanged attributes hidden)
        }



        # (4 unchanged blocks hidden)
    }

Plan: 7 to add, 1 to change, 0 to destroy.

```