### PR TITLE
SE-1773 - fix unnecessary diff with target-health

### DIFF
--- a/apps/mdn/mdn-dev/main.tf
+++ b/apps/mdn/mdn-dev/main.tf
@@ -41,11 +41,12 @@ module "dns-mozit" {
 }
 
 module "dns-mdn-dev" {
-  source            = "./modules/dns"
-  domain-zone-id    = data.terraform_remote_state.dns.outputs.mdn-dev-zone
-  domain-name       = "mdn.dev"
-  domain-name-alias = module.mdn-dev.cloudfront_domain
-  alias-zone-id     = module.mdn-dev.cloudfront_hosted_zone_id
+  source                 = "./modules/dns"
+  domain-zone-id         = data.terraform_remote_state.dns.outputs.mdn-dev-zone
+  domain-name            = "mdn.dev"
+  domain-name-alias      = module.mdn-dev.cloudfront_domain
+  alias-zone-id          = module.mdn-dev.cloudfront_hosted_zone_id
+  evaluate-target-health = false
 }
 
 module "mdn-dev" {


### PR DESCRIPTION
I was applying the changes to upgrade the lambda runtime for mdn.dev and noticed this unnecessary diff. Removes the following from the terraform plan for this product.
```bash
  # module.dns-mdn-dev.aws_route53_record.main will be updated in-place                                                        
  ~ resource "aws_route53_record" "main" {                                                                                     
        allow_overwrite = true                                                                                                 
        fqdn            = "mdn.dev"                                                                                            
        id              = "Z2MZJ35C5P93MD_mdn.dev_A"           
        name            = "mdn.dev"                                                                                            
        records         = []                                                                                                   
        ttl             = 0                                                                                                                                                                                                                                   
        type            = "A"                                                                                                  
        zone_id         = "Z2MZJ35C5P93MD" 
                                                               
      - alias {                                                                                                                
          - evaluate_target_health = false -> null                                                                             
          - name                   = "d2pgkrr49jx816.cloudfront.net" -> null
          - zone_id                = "Z2FDTNDATAQYW2" -> null                                                                  
        }                                                                                                                      
      + alias {                                                                                                                
          + evaluate_target_health = true                                                                                      
          + name                   = "d2pgkrr49jx816.cloudfront.net"                                                                                                                                                                                          
          + zone_id                = "Z2FDTNDATAQYW2"                                                                          
        }                                                                                                                      
    } 
```