### PR TITLE
Migrate module name to reflect region we are actually using

### DIFF
--- a/apps/mdn/ssh-tunnel/main.tf
+++ b/apps/mdn/ssh-tunnel/main.tf
@@ -1,4 +1,4 @@
-module "ssh_tunnel_eu_central_1" {
+module "ssh_tunnel_us_west_2" {
   source     = "./modules/ssh-tunnel"
   region     = "us-west-2"
   spot_price = "0.0021"

--- a/apps/mdn/ssh-tunnel/outputs.tf
+++ b/apps/mdn/ssh-tunnel/outputs.tf
@@ -1,7 +1,7 @@
 output "tunnel_server_ip" {
-  value = module.ssh_tunnel_eu_central_1.tunnel_server_ip
+  value = module.ssh_tunnel_us_west_2.tunnel_server_ip
 }
 
 output "tunnel_fqdn" {
-  value = module.ssh_tunnel_eu_central_1.tunnel_fqdn
+  value = module.ssh_tunnel_us_west_2.tunnel_fqdn
 }


### PR DESCRIPTION
This really confused me when reviewing @fiji-flo 's last PR. I already `terraform st mv`'d this and `terraform apply`d cleanly