### PR TITLE
Add redash RDS instance to TF

### DIFF
--- a/apps/mdn/mdn-aws/README.md
+++ b/apps/mdn/mdn-aws/README.md
@@ -5,6 +5,14 @@
 
 ## MDN AWS provisioning
 
+---
+- ### NOTE  arm64/Apple Silicon users.
+
+  As of writing (Terraform v1.1.8) you will need to do run the following before executing terraform commands
+
+  -  ```export GODEBUG=asyncpreemptoff=1 ```
+
+--- 
 ### Requirements:
 
 - Terraform

--- a/apps/mdn/mdn-aws/infra/locals.tf
+++ b/apps/mdn/mdn-aws/infra/locals.tf
@@ -4,7 +4,7 @@ locals {
     username                = "root"
     postgres_username       = "postgres"
     engine_version          = "5.6.51"
-    postgres_engine_version = "13.3"
+    postgres_engine_version = "13.4"
     backup_retention_days   = "1"
     storage_type            = "gp2"
     storage_gb              = "100"
@@ -24,13 +24,21 @@ locals {
       backup_retention_days = "1"
       storage_gb            = "100"
       postgres_storage_gb   = "20"
-    },
+    },    
     prod = {
       db_name               = "developer_mozilla_org"
       password              = ""
       instance_class        = "db.m5.xlarge"
       backup_retention_days = "7"
       storage_gb            = "200"
+    }
+    redash = { 
+      db_name               = "mdn_redash"
+      password              = ""
+      instance_class        = "db.t2.small"
+      backup_retention_days = "1"
+      storage_gb            = "100"
+      postgres_storage_gb   = "20"
     }
   }
 

--- a/apps/mdn/mdn-aws/infra/main.tf
+++ b/apps/mdn/mdn-aws/infra/main.tf
@@ -145,6 +145,30 @@ module "mysql-us-west-2" {
   monitoring_interval     = "60"
 }
 
+module "postgres-stage-redash-us-west-2" {
+
+  source      = "./modules/multi_region/rds"
+  enabled     = lookup(var.features, "rds")
+  environment = "stage"
+  region      = "us-west-2"
+
+  # postgres database
+  postgres_db_name               = local.rds["redash"]["db_name"]
+  postgres_username              = local.rds["redash"]["postgres_username"]
+  postgres_password              = var.rds["redash"]["password"]
+  postgres_identifier            = "mdn-stage-redash-postgres"
+  postgres_engine_version        = local.rds["redash"]["postgres_engine_version"]
+  postgres_instance_class        = local.rds["redash"]["instance_class"]
+  postgres_backup_retention_days = local.rds["redash"]["backup_retention_days"]
+  postgres_storage_gb            = local.rds["redash"]["postgres_storage_gb"]
+  postgres_storage_type          = local.rds["redash"]["storage_type"]
+
+  # shared
+  rds_security_group_name = "mdn_rds_sg_stage"
+  vpc_id                  = data.terraform_remote_state.vpc-us-west-2.outputs.vpc_id
+  monitoring_interval     = "60"
+}
+
 module "mysql-us-west-2-prod" {
   source      = "./modules/multi_region/rds"
   enabled     = var.features["rds"]

--- a/apps/mdn/mdn-aws/infra/main.tf
+++ b/apps/mdn/mdn-aws/infra/main.tf
@@ -164,6 +164,8 @@ module "postgres-stage-redash-us-west-2" {
   postgres_storage_type          = local.rds["redash"]["storage_type"]
 
   # shared
+  rds_security_group_id   = module.mysql-us-west-2.rds_security_group_id
+  rds_subnet_group_name   = module.mysql-us-west-2.rds_subnet_group_name
   rds_security_group_name = "mdn_rds_sg_stage"
   vpc_id                  = data.terraform_remote_state.vpc-us-west-2.outputs.vpc_id
   monitoring_interval     = "60"

--- a/apps/mdn/mdn-aws/infra/modules/multi_region/rds/outputs.tf
+++ b/apps/mdn/mdn-aws/infra/modules/multi_region/rds/outputs.tf
@@ -13,3 +13,11 @@ output "postgres_rds_endpoint" {
 output "postgres_rds_id" {
   value = element(concat(aws_db_instance.mdn_postgres.*.id, [""]), 0)
 }
+
+output "rds_security_group_id" {
+  value = element(concat(aws_security_group.mdn_rds_sg.*.id, [""]), 0)
+}
+
+output "rds_subnet_group_name" {
+  value = element(concat(aws_db_subnet_group.rds.*.name, [""]), 0)
+}

--- a/apps/mdn/mdn-aws/infra/modules/multi_region/rds/variables.tf
+++ b/apps/mdn/mdn-aws/infra/modules/multi_region/rds/variables.tf
@@ -9,6 +9,16 @@ variable "enabled" {
 variable "rds_security_group_name" {
 }
 
+variable "rds_security_group_id" {
+  default = ""
+  description = "security_group_id"
+}
+
+variable "rds_subnet_group_name" {
+  default = ""
+  description = "security_group_name"
+}
+
 variable "postgres_port" {
   default     = 5432
   description = "ingress port to open"


### PR DESCRIPTION
FIX: postgres_engine_version - Bumped to 13.4 to sync with RDS environment.

FEAT: Added Redash postgres to staging environment. 

Depends on https://github.com/mozilla/mdn-k8s-private/pull/153