### PR TITLE
Se 3219 k8s upgrade

### DIFF
--- a/k8s/clusters/eu-central-1/locals.tf
+++ b/k8s/clusters/eu-central-1/locals.tf
@@ -18,7 +18,7 @@ locals {
       disk_size        = "50"
       instance_types   = ["m5.large"]
       subnets          = data.terraform_remote_state.vpc-eu-central-1.outputs.public_subnets
-      ami_id           = "ami-04ea0b353c9bfb834"
+      ami_id           = "ami-0adb057ced8202b06"
 
       k8s_label = {
         Service = "default"

--- a/k8s/clusters/eu-central-1/locals.tf
+++ b/k8s/clusters/eu-central-1/locals.tf
@@ -2,15 +2,15 @@ locals {
 
   cluster_features = {
     "aws_calico"  = true
-    "alb_ingress" = true
+    "alb_ingress" = false
     "reloader"    = false
   }
 
   velero_bucket_name = "velero-${module.mdn.cluster_id}-${var.region}-${data.aws_caller_identity.current.account_id}"
 
   mdn_node_groups = {
-    blue-workers = {
-      name = "mdn-blue-workers"
+    green-workers = {
+      name = "mdn-green-workers"
 
       desired_capacity = "2"
       min_capacity     = "2"
@@ -18,7 +18,6 @@ locals {
       disk_size        = "50"
       instance_types   = ["m5.large"]
       subnets          = data.terraform_remote_state.vpc-eu-central-1.outputs.public_subnets
-      ami_id           = "ami-0adb057ced8202b06"
 
       k8s_label = {
         Service = "default"
@@ -26,7 +25,7 @@ locals {
       }
 
       additional_tags = {
-        "Name"                              = "mdn-blue-workers"
+        "Name"                              = "mdn-green-workers"
         "kubernetes.io/cluster/mdn"         = "owned"
         "k8s.io/cluster-autoscaler/enabled" = "true"
       }

--- a/k8s/clusters/eu-central-1/main.tf
+++ b/k8s/clusters/eu-central-1/main.tf
@@ -20,7 +20,7 @@ module "mdn" {
   cluster_subnets = data.terraform_remote_state.vpc-eu-central-1.outputs.public_subnets
 
   cluster_name       = "mdn"
-  cluster_version    = "1.19"
+  cluster_version    = "1.21"
   cluster_features   = local.cluster_features
   node_groups        = local.mdn_node_groups
   map_roles          = local.map_roles

--- a/k8s/clusters/eu-central-1/main.tf
+++ b/k8s/clusters/eu-central-1/main.tf
@@ -13,7 +13,7 @@ module "ssh_sg" {
 }
 
 module "mdn" {
-  source = "github.com/mozilla-it/terraform-modules//aws/eks?ref=add-1.22"
+  source = "github.com/mozilla-it/terraform-modules//aws/eks?ref=master"
 
   region          = var.region
   vpc_id          = data.terraform_remote_state.vpc-eu-central-1.outputs.vpc_id

--- a/k8s/clusters/eu-central-1/main.tf
+++ b/k8s/clusters/eu-central-1/main.tf
@@ -13,14 +13,14 @@ module "ssh_sg" {
 }
 
 module "mdn" {
-  source = "github.com/mozilla-it/terraform-modules//aws/eks?ref=master"
+  source = "github.com/mozilla-it/terraform-modules//aws/eks?ref=add-1.22"
 
   region          = var.region
   vpc_id          = data.terraform_remote_state.vpc-eu-central-1.outputs.vpc_id
   cluster_subnets = data.terraform_remote_state.vpc-eu-central-1.outputs.public_subnets
 
   cluster_name       = "mdn"
-  cluster_version    = "1.21"
+  cluster_version    = "1.22"
   cluster_features   = local.cluster_features
   node_groups        = local.mdn_node_groups
   map_roles          = local.map_roles

--- a/k8s/clusters/us-west-2/locals.tf
+++ b/k8s/clusters/us-west-2/locals.tf
@@ -7,8 +7,8 @@ locals {
   }
 
   mdn_node_groups = {
-    green-workers = {
-      name = "mdn-green-workers"
+    blue-workers = {
+      name = "mdn-blue-workers"
 
       desired_capacity = "4"
       min_capacity     = "4"
@@ -16,7 +16,7 @@ locals {
       disk_size        = "100"
       instance_types   = ["m5.xlarge"]
       subnets          = data.terraform_remote_state.vpc-us-west-2.outputs.public_subnets
-      ami_id = "ami-0e9d7772961b84bc8"
+      ami_id           = "ami-0aa4096ec49a62235"
 
       k8s_label = {
         Service = "default"
@@ -24,7 +24,7 @@ locals {
       }
 
       additional_tags = {
-        "Name"                              = "mdn-green-workers"
+        "Name"                              = "mdn-blue-workers"
         "kubernetes.io/cluster/mdn"         = "owned"
         "k8s.io/cluster-autoscaler/enabled" = "true"
       }

--- a/k8s/clusters/us-west-2/main.tf
+++ b/k8s/clusters/us-west-2/main.tf
@@ -46,7 +46,7 @@ module "mdn" {
   cluster_subnets = data.terraform_remote_state.vpc-us-west-2.outputs.public_subnets
 
   cluster_name       = "mdn"
-  cluster_version    = "1.19"
+  cluster_version    = "1.20"
   cluster_features   = local.cluster_features
   node_groups        = local.mdn_node_groups
   map_roles          = local.map_roles


### PR DESCRIPTION
Not many diffs in the code here but a lot work in the terminal. I upgrade the `eu-central-1` cluster to 1.22 as per requested in the ticket. This ended up being extremely painful and difficult. 

For now we are going to upgrade the cluster to 1.20 and circle back to upgrade to 1.22 at a later date. Please see the ticket for more information https://mozilla-hub.atlassian.net/browse/SE-3219

