### PR TITLE
chore(external-secrets): Remove external secrets from these clusters as they are not used

### DIFF
--- a/k8s/clusters/eu-central-1/locals.tf
+++ b/k8s/clusters/eu-central-1/locals.tf
@@ -1,9 +1,12 @@
 locals {
 
   cluster_features = {
-    "aws_calico"  = true
-    "alb_ingress" = false
-    "reloader"    = false
+    # aws_calico migrated to calico
+    # installed with helm manually in the cluster
+    "aws_calico"       = false
+    "alb_ingress"      = false
+    "reloader"         = false
+    "external_secrets" = false
   }
 
   velero_bucket_name = "velero-${module.mdn.cluster_id}-${var.region}-${data.aws_caller_identity.current.account_id}"

--- a/k8s/clusters/us-west-2/locals.tf
+++ b/k8s/clusters/us-west-2/locals.tf
@@ -1,9 +1,11 @@
 locals {
 
   cluster_features = {
-    "aws_calico"  = true
-    "alb_ingress" = true
-    "reloader"    = false
+    // calico managed by helm separately
+    "aws_calico"       = false
+    "alb_ingress"      = true
+    "reloader"         = false
+    "external_secrets" = false
   }
 
   mdn_node_groups = {


### PR DESCRIPTION
It's possible Calico is also not used at all but it is at least using a new enough SDK that we should be good for a 1.22 upgrade.